### PR TITLE
InputBase component

### DIFF
--- a/.changeset/slick-news-cheat.md
+++ b/.changeset/slick-news-cheat.md
@@ -1,0 +1,5 @@
+---
+"@scaffold-ui/components": patch
+---
+
+feat: have common BaseInput for Input components

--- a/example/app/components/UseAddressInputExample.tsx
+++ b/example/app/components/UseAddressInputExample.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AddressInput, InputBase } from "@scaffold-ui/components";
+import { AddressInput, BaseInput } from "@scaffold-ui/components";
 import { useAddressInput } from "@scaffold-ui/hooks";
 import { useState } from "react";
 import { Address } from "viem";
@@ -83,7 +83,7 @@ export const UseAddressInputExample = () => {
               </div>
             )
           )}
-          <InputBase<Address>
+          <BaseInput<Address>
             name="address"
             placeholder="Address Input"
             error={ensAddress === null}

--- a/example/app/components/UseAddressInputExample.tsx
+++ b/example/app/components/UseAddressInputExample.tsx
@@ -39,6 +39,19 @@ export const UseAddressInputExample = () => {
               <span className="text-sm text-gray-500 mb-1">With placeholder</span>
               <AddressInput value={value} onChange={setValue} placeholder="Enter an address" />
             </div>
+
+            <div className="flex flex-col">
+              <span className="text-sm text-gray-500 mb-1">Custom colors</span>
+              <AddressInput
+                value={value}
+                onChange={setValue}
+                colors={{
+                  border: "#22c55e",
+                  background: "#dcfce7",
+                  text: "#166534",
+                }}
+              />
+            </div>
           </div>
         </div>
 

--- a/example/app/components/UseAddressInputExample.tsx
+++ b/example/app/components/UseAddressInputExample.tsx
@@ -64,9 +64,7 @@ export const UseAddressInputExample = () => {
           {ensAddress ? <div className="bg-[#dae8ff] items-center">Address: {ensAddress}</div> : null}
           {ensName ? (
             <div className="flex bg-[#dae8ff] rounded-l-full items-center">
-              {isEnsAvatarLoading && (
-                <div className="skeleton bg-base-200 w-[35px] h-[35px] rounded-full shrink-0"></div>
-              )}
+              {isEnsAvatarLoading && <div className="skeleton w-[35px] h-[35px] rounded-full shrink-0"></div>}
               {ensAvatar ? (
                 <span className="w-[35px]">
                   {

--- a/example/app/components/UseEtherInputExample.tsx
+++ b/example/app/components/UseEtherInputExample.tsx
@@ -43,6 +43,21 @@ export const UseEtherInputExample = () => {
             <span className="text-sm text-gray-500 mb-1 self-start">Default value</span>
             <EtherInput name="ether-input-default-value" defaultValue="10" />
           </div>
+          <div className="flex flex-col">
+            <span className="text-sm text-gray-500 mb-1 self-start">Custom</span>
+            <EtherInput
+              name="ether-input-usd-mode"
+              defaultUsdMode
+              onValueChange={({ valueInEth, valueInUsd, displayUsdMode }) =>
+                console.log("value changed", valueInEth, valueInUsd, displayUsdMode)
+              }
+              colors={{
+                border: "#eab308",
+                background: "#fef9c3",
+                text: "#713f12",
+              }}
+            />
+          </div>
         </div>
       </div>
 

--- a/packages/components/src/Input/AddressInput.tsx
+++ b/packages/components/src/Input/AddressInput.tsx
@@ -1,7 +1,7 @@
 import { blo } from "blo";
 import { Address } from "viem";
 import { useAddressInput } from "@scaffold-ui/hooks";
-import { InputBase } from "./InputBase";
+import { InputBase, DEFAULT_COLORS } from "./InputBase";
 import { CommonInputProps } from "./utils";
 import { useEffect, useState } from "react";
 
@@ -24,6 +24,10 @@ export type AddressInputProps = CommonInputProps<Address | string>;
  * @param {string} [props.placeholder] - (Optional) Placeholder text for the input field.
  * @param {(value: Address) => void} [props.onChange] - Callback function called when the input value changes.
  * @param {boolean} [props.disabled] - (Optional) Whether the input is disabled.
+ * @param {string} [props.colors] - (Optional) Colors for the input.
+ * @param {string} [props.colors.border] - Border color.
+ * @param {string} [props.colors.background] - Background color.
+ * @param {string} [props.colors.text] - Text color.
  *
  * @example
  * <AddressInput
@@ -38,7 +42,14 @@ export type AddressInputProps = CommonInputProps<Address | string>;
  *   disabled={false}
  * />
  */
-export const AddressInput = ({ value, name, placeholder, onChange, disabled }: AddressInputProps) => {
+export const AddressInput = ({
+  value,
+  name,
+  placeholder,
+  onChange,
+  disabled,
+  colors = DEFAULT_COLORS,
+}: AddressInputProps) => {
   const {
     ensAddress,
     ensName,
@@ -87,24 +98,47 @@ export const AddressInput = ({ value, name, placeholder, onChange, disabled }: A
       onChange={onChange}
       disabled={isEnsAddressLoading || isEnsNameLoading || disabled}
       reFocus={reFocus}
+      colors={colors}
       prefix={
         ensName ? (
-          <div className="flex bg-[#dae8ff] rounded-l-full items-center">
+          <div
+            className="flex rounded-l-full items-center"
+            style={{
+              backgroundColor: colors.border,
+            }}
+          >
             {isEnsAvatarLoading && (
-              <div className="animate-pulse bg-[#f4f8ff] w-[35px] h-[35px] rounded-full shrink-0"></div>
+              <div
+                className="animate-pulse w-[35px] h-[35px] rounded-full shrink-0"
+                style={{
+                  backgroundColor: colors.background,
+                }}
+              />
             )}
             {ensAvatar ? (
               <span className="w-[35px]">
                 <img className="w-full rounded-full" src={ensAvatar} alt={`${ensAddress} avatar`} />
               </span>
             ) : null}
-            <span className="text-[#93bbfb] px-2">{enteredEnsName ?? ensName}</span>
+            <span className="px-2" style={{ color: colors.text }}>
+              {enteredEnsName ?? ensName}
+            </span>
           </div>
         ) : (
           (isEnsNameLoading || isEnsAddressLoading) && (
-            <div className="flex bg-[#dae8ff] rounded-l-full items-center gap-2 pr-2">
-              <div className="animate-pulse bg-[#f4f8ff] w-[35px] h-[35px] rounded-full shrink-0"></div>
-              <div className="animate-pulse bg-[#f4f8ff] h-3 w-20"></div>
+            <div
+              className="flex rounded-l-full items-center gap-2 pr-2"
+              style={{
+                backgroundColor: colors.border,
+              }}
+            >
+              <div
+                className="animate-pulse w-[35px] h-[35px] rounded-full shrink-0"
+                style={{
+                  backgroundColor: colors.background,
+                }}
+              />
+              <div className="animate-pulse h-3 w-20" style={{ backgroundColor: colors.background }} />
             </div>
           )
         )

--- a/packages/components/src/Input/AddressInput.tsx
+++ b/packages/components/src/Input/AddressInput.tsx
@@ -1,7 +1,7 @@
 import { blo } from "blo";
 import { Address } from "viem";
 import { useAddressInput } from "@scaffold-ui/hooks";
-import { InputBase, DEFAULT_COLORS } from "./InputBase";
+import { BaseInput, DEFAULT_COLORS } from "./BaseInput";
 import { CommonInputProps } from "./utils";
 import { useEffect, useState } from "react";
 
@@ -90,7 +90,7 @@ export const AddressInput = ({
   }, [value]);
 
   return (
-    <InputBase<Address>
+    <BaseInput<Address>
       name={name}
       placeholder={placeholder}
       error={ensAddress === null}

--- a/packages/components/src/Input/BaseInput.tsx
+++ b/packages/components/src/Input/BaseInput.tsx
@@ -1,7 +1,7 @@
 import { ChangeEvent, FocusEvent, ReactNode, useCallback, useEffect, useRef } from "react";
 import { CommonInputProps } from "./utils";
 
-export type InputBaseProps<T> = CommonInputProps<T> & {
+export type BaseInputProps<T> = CommonInputProps<T> & {
   error?: boolean;
   prefix?: ReactNode;
   suffix?: ReactNode;
@@ -15,7 +15,7 @@ export const DEFAULT_COLORS = {
 };
 
 /**
- * InputBase Component
+ * BaseInput Component
  *
  * A flexible, styled input component used as the foundation for custom inputs (e.g., EtherInput, AddressInput).
  * - Supports prefix and suffix elements for icons or adornments.
@@ -24,7 +24,7 @@ export const DEFAULT_COLORS = {
  * - Accepts custom color classes for border, background, and text.
  *
  * @template T - The value type, must have a toString method (e.g., string, Address).
- * @param {InputBaseProps<T>} props - The props for the InputBase component.
+ * @param {BaseInputProps<T>} props - The props for the BaseInput component.
  * @param {string} [props.name] - (Optional) The name attribute for the input element.
  * @param {T} [props.value] - The value of the input.
  * @param {(value: T) => void} props.onChange - Callback fired when the input value changes.
@@ -40,7 +40,7 @@ export const DEFAULT_COLORS = {
  * @param {string} [props.colors.text] - Text color.
  *
  * @example
- * <InputBase
+ * <BaseInput
  *   name="username"
  *   value={value}
  *   onChange={setValue}
@@ -49,7 +49,7 @@ export const DEFAULT_COLORS = {
  *   error={hasError}
  * />
  */
-export const InputBase = <T extends { toString: () => string } | undefined = string>({
+export const BaseInput = <T extends { toString: () => string } | undefined = string>({
   name,
   value,
   onChange,
@@ -60,7 +60,7 @@ export const InputBase = <T extends { toString: () => string } | undefined = str
   suffix,
   reFocus,
   colors = DEFAULT_COLORS,
-}: InputBaseProps<T>) => {
+}: BaseInputProps<T>) => {
   const inputReft = useRef<HTMLInputElement>(null);
 
   let modifier = "";

--- a/packages/components/src/Input/EtherInput.tsx
+++ b/packages/components/src/Input/EtherInput.tsx
@@ -1,14 +1,12 @@
 import { useEffect, useRef, useState } from "react";
 import { MAX_DECIMALS_USD, useEtherInput } from "@scaffold-ui/hooks";
 import { SwitchIcon } from "../icons/SwitchIcon";
-import { InputBase } from "./InputBase";
+import { DEFAULT_COLORS, InputBase } from "./InputBase";
+import { CommonInputProps } from "./utils";
 
-export type EtherInputProps = {
-  name?: string;
-  placeholder?: string;
+export type EtherInputProps = Omit<CommonInputProps<string>, "onChange" | "value"> & {
   defaultValue?: string;
   defaultUsdMode?: boolean;
-  disabled?: boolean;
   onValueChange?: (value: { valueInEth: string; valueInUsd: string; displayUsdMode: boolean }) => void;
 };
 
@@ -30,6 +28,10 @@ const SIGNED_NUMBER_REGEX = /^-?\d+\.?\d*$/;
  * @param {boolean} [props.defaultUsdMode] - (Optional) If true, input starts in USD mode; otherwise, ETH mode.
  * @param {boolean} [props.disabled] - (Optional) If true, the input and toggle button are disabled.
  * @param {(value: { valueInEth: string; valueInUsd: string; usdMode: boolean }) => void} props.onValueChange - (Optional) Callback fired when the value or mode changes.
+ * @param {string} [props.colors] - (Optional) Colors for the input.
+ * @param {string} [props.colors.border] - Border color.
+ * @param {string} [props.colors.background] - Background color.
+ * @param {string} [props.colors.text] - Text color.
  *
  * @example
  * <EtherInput onValueChange={({ valueInEth, valueInUsd, usdMode }) => { ... }} />
@@ -42,6 +44,7 @@ export const EtherInput = ({
   defaultUsdMode,
   disabled,
   onValueChange,
+  colors = DEFAULT_COLORS,
 }: EtherInputProps) => {
   const [sourceValue, setSourceValue] = useState(defaultValue ?? "");
   const [sourceUsdMode, setSourceUsdMode] = useState(defaultUsdMode ?? false);
@@ -94,6 +97,7 @@ export const EtherInput = ({
         onChange={handleInputChange}
         disabled={isNativeCurrencyPriceLoading || disabled}
         prefix={<span className="pl-4 -mr-2 text-accent self-center">{displayUsdMode ? "$" : "Ξ"}</span>}
+        colors={colors}
         suffix={
           <button
             className="h-[2.2rem] min-h-[2.2rem] cursor-pointer mr-3"

--- a/packages/components/src/Input/EtherInput.tsx
+++ b/packages/components/src/Input/EtherInput.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { MAX_DECIMALS_USD, useEtherInput } from "@scaffold-ui/hooks";
 import { SwitchIcon } from "../icons/SwitchIcon";
-import { DEFAULT_COLORS, InputBase } from "./InputBase";
+import { DEFAULT_COLORS, BaseInput } from "./BaseInput";
 import { CommonInputProps } from "./utils";
 
 export type EtherInputProps = Omit<CommonInputProps<string>, "onChange" | "value"> & {
@@ -90,7 +90,7 @@ export const EtherInput = ({
 
   return (
     <div className="flex items-center gap-2">
-      <InputBase<string>
+      <BaseInput<string>
         name={name}
         value={activeValue}
         placeholder={placeholder}

--- a/packages/components/src/Input/EtherInput.tsx
+++ b/packages/components/src/Input/EtherInput.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { MAX_DECIMALS_USD, useEtherInput } from "@scaffold-ui/hooks";
-import { SwitchIcon } from "./icons/SwitchIcon";
+import { SwitchIcon } from "../icons/SwitchIcon";
+import { InputBase } from "./InputBase";
 
 export type EtherInputProps = {
   name?: string;
@@ -62,8 +63,7 @@ export const EtherInput = ({
     }
   }, [valueInEth, valueInUsd, displayUsdMode]);
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
+  const handleInputChange = (value: string) => {
     if (value && !SIGNED_NUMBER_REGEX.test(value)) {
       return;
     }
@@ -87,35 +87,35 @@ export const EtherInput = ({
 
   return (
     <div className="flex items-center gap-2">
-      <span className="pl-4 -mr-2 text-accent self-center">{displayUsdMode ? "$" : "Ξ"}</span>
-      <input
+      <InputBase<string>
         name={name}
         value={activeValue}
         placeholder={placeholder}
         onChange={handleInputChange}
         disabled={isNativeCurrencyPriceLoading || disabled}
-        className="input input-bordered w-40"
-        autoComplete="off"
-      />
-      <button
-        className="btn btn-primary h-[2.2rem] min-h-[2.2rem] cursor-pointer"
-        onClick={(e) => {
-          e.preventDefault();
-          handleToggleMode();
-        }}
-        disabled={isNativeCurrencyPriceLoading || isNativeCurrencyPriceError || disabled}
-        type="button"
-        tabIndex={-1}
-        title={
-          isNativeCurrencyPriceLoading
-            ? "Fetching price"
-            : isNativeCurrencyPriceError
-              ? "Unable to fetch price"
-              : "Toggle USD/ETH"
+        prefix={<span className="pl-4 -mr-2 text-accent self-center">{displayUsdMode ? "$" : "Ξ"}</span>}
+        suffix={
+          <button
+            className="h-[2.2rem] min-h-[2.2rem] cursor-pointer mr-3"
+            onClick={(e) => {
+              e.preventDefault();
+              handleToggleMode();
+            }}
+            disabled={isNativeCurrencyPriceLoading || isNativeCurrencyPriceError || disabled}
+            type="button"
+            tabIndex={-1}
+            title={
+              isNativeCurrencyPriceLoading
+                ? "Fetching price"
+                : isNativeCurrencyPriceError
+                  ? "Unable to fetch price"
+                  : "Toggle USD/ETH"
+            }
+          >
+            <SwitchIcon width={16} height={16} />
+          </button>
         }
-      >
-        <SwitchIcon width={16} height={16} />
-      </button>
+      />
     </div>
   );
 };

--- a/packages/components/src/Input/InputBase.tsx
+++ b/packages/components/src/Input/InputBase.tsx
@@ -6,8 +6,41 @@ export type InputBaseProps<T> = CommonInputProps<T> & {
   prefix?: ReactNode;
   suffix?: ReactNode;
   reFocus?: boolean;
+  colorClassName?: string;
 };
 
+/**
+ * InputBase Component
+ *
+ * A flexible, styled input component used as the foundation for custom inputs (e.g., EtherInput, AddressInput).
+ * - Supports prefix and suffix elements for icons or adornments.
+ * - Handles error and disabled states with visual feedback.
+ * - Can auto-focus and set cursor position at the end when `reFocus` is true (useful for programmatic focus).
+ * - Accepts custom color classes for border, background, and text.
+ *
+ * @template T - The value type, must have a toString method (e.g., string, Address).
+ * @param {InputBaseProps<T>} props - The props for the InputBase component.
+ * @param {string} [props.name] - (Optional) The name attribute for the input element.
+ * @param {T} [props.value] - The value of the input.
+ * @param {(value: T) => void} props.onChange - Callback fired when the input value changes.
+ * @param {string} [props.placeholder] - (Optional) Placeholder text for the input.
+ * @param {boolean} [props.error] - (Optional) If true, input is styled as error.
+ * @param {boolean} [props.disabled] - (Optional) If true, the input is disabled.
+ * @param {ReactNode} [props.prefix] - (Optional) Element to render before the input (e.g., icon).
+ * @param {ReactNode} [props.suffix] - (Optional) Element to render after the input (e.g., button).
+ * @param {boolean} [props.reFocus] - (Optional) If true, input auto-focuses and cursor moves to end.
+ * @param {string} [props.colorClassName] - (Optional) Tailwind classes for border, background, and text.
+ *
+ * @example
+ * <InputBase
+ *   name="username"
+ *   value={value}
+ *   onChange={setValue}
+ *   placeholder="Enter your name"
+ *   prefix={<UserIcon />}
+ *   error={hasError}
+ * />
+ */
 export const InputBase = <T extends { toString: () => string } | undefined = string>({
   name,
   value,
@@ -18,6 +51,7 @@ export const InputBase = <T extends { toString: () => string } | undefined = str
   prefix,
   suffix,
   reFocus,
+  colorClassName = "border-[#dae8ff] bg-[#f4f8ff] text-[#93bbfb]",
 }: InputBaseProps<T>) => {
   const inputReft = useRef<HTMLInputElement>(null);
 
@@ -47,10 +81,10 @@ export const InputBase = <T extends { toString: () => string } | undefined = str
   }, [reFocus]);
 
   return (
-    <div className={`flex border-2 border-[#dae8ff] bg-[#f4f8ff] rounded-full text-[#93bbfb] ${modifier}`}>
+    <div className={`flex border-2 rounded-full ${colorClassName} ${modifier}`}>
       {prefix}
       <input
-        className={`w-full h-[2.2rem] min-h-[2.2rem] px-4 border-0 bg-transparent font-medium placeholder:text-[#93bbfb]/70 text-[#93bbfb]/70 focus:text-[#93bbfb]/70 focus:outline-none focus:ring-0 ${
+        className={`w-full h-[2.2rem] min-h-[2.2rem] px-4 border-0 bg-transparent font-medium focus:outline-none focus:ring-0 opacity-80 ${
           disabled ? "cursor-not-allowed" : ""
         }`}
         placeholder={placeholder}

--- a/packages/components/src/Input/InputBase.tsx
+++ b/packages/components/src/Input/InputBase.tsx
@@ -6,7 +6,12 @@ export type InputBaseProps<T> = CommonInputProps<T> & {
   prefix?: ReactNode;
   suffix?: ReactNode;
   reFocus?: boolean;
-  colorClassName?: string;
+};
+
+export const DEFAULT_COLORS = {
+  border: "#dae8ff",
+  background: "#f4f8ff",
+  text: "#93bbfb",
 };
 
 /**
@@ -29,7 +34,10 @@ export type InputBaseProps<T> = CommonInputProps<T> & {
  * @param {ReactNode} [props.prefix] - (Optional) Element to render before the input (e.g., icon).
  * @param {ReactNode} [props.suffix] - (Optional) Element to render after the input (e.g., button).
  * @param {boolean} [props.reFocus] - (Optional) If true, input auto-focuses and cursor moves to end.
- * @param {string} [props.colorClassName] - (Optional) Tailwind classes for border, background, and text.
+ * @param {string} [props.colors] - (Optional) Colors for the input.
+ * @param {string} [props.colors.border] - Border color.
+ * @param {string} [props.colors.background] - Background color.
+ * @param {string} [props.colors.text] - Text color.
  *
  * @example
  * <InputBase
@@ -51,15 +59,15 @@ export const InputBase = <T extends { toString: () => string } | undefined = str
   prefix,
   suffix,
   reFocus,
-  colorClassName = "border-[#dae8ff] bg-[#f4f8ff] text-[#93bbfb]",
+  colors = DEFAULT_COLORS,
 }: InputBaseProps<T>) => {
   const inputReft = useRef<HTMLInputElement>(null);
 
   let modifier = "";
   if (error) {
-    modifier = "border-red-400";
+    modifier = "border-red-400!";
   } else if (disabled) {
-    modifier = "border-gray-300 bg-base-300";
+    modifier = "border-gray-300! bg-base-300!";
   }
 
   const handleChange = useCallback(
@@ -81,10 +89,17 @@ export const InputBase = <T extends { toString: () => string } | undefined = str
   }, [reFocus]);
 
   return (
-    <div className={`flex border-2 rounded-full ${colorClassName} ${modifier}`}>
+    <div
+      className={`flex border-2 rounded-full ${modifier}`}
+      style={{
+        borderColor: colors.border,
+        backgroundColor: colors.background,
+        color: colors.text,
+      }}
+    >
       {prefix}
       <input
-        className={`w-full h-[2.2rem] min-h-[2.2rem] px-4 border-0 bg-transparent font-medium focus:outline-none focus:ring-0 opacity-80 ${
+        className={`w-full h-[2.2rem] min-h-[2.2rem] px-4 border-0 bg-transparent font-medium focus:outline-none focus:ring-0 ${
           disabled ? "cursor-not-allowed" : ""
         }`}
         placeholder={placeholder}

--- a/packages/components/src/Input/InputBase.tsx
+++ b/packages/components/src/Input/InputBase.tsx
@@ -67,7 +67,7 @@ export const InputBase = <T extends { toString: () => string } | undefined = str
   if (error) {
     modifier = "border-red-400!";
   } else if (disabled) {
-    modifier = "border-gray-300! bg-base-300!";
+    modifier = "border-gray-300!";
   }
 
   const handleChange = useCallback(

--- a/packages/components/src/Input/index.ts
+++ b/packages/components/src/Input/index.ts
@@ -1,3 +1,3 @@
-export { InputBase, type InputBaseProps } from "./InputBase.js";
+export { BaseInput, type BaseInputProps } from "./BaseInput.js";
 export { AddressInput, type AddressInputProps } from "./AddressInput.js";
 export { EtherInput, type EtherInputProps } from "./EtherInput.js";

--- a/packages/components/src/Input/index.ts
+++ b/packages/components/src/Input/index.ts
@@ -1,2 +1,3 @@
 export { InputBase, type InputBaseProps } from "./InputBase.js";
 export { AddressInput, type AddressInputProps } from "./AddressInput.js";
+export { EtherInput, type EtherInputProps } from "./EtherInput.js";

--- a/packages/components/src/Input/utils.ts
+++ b/packages/components/src/Input/utils.ts
@@ -4,4 +4,9 @@ export type CommonInputProps<T = string> = {
   name?: string;
   placeholder?: string;
   disabled?: boolean;
+  colors?: {
+    border: string;
+    background: string;
+    text: string;
+  };
 };

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,4 +1,10 @@
 export { Address, type AddressProps } from "./Address";
 export { Balance, type BalanceProps } from "./Balance";
-export { InputBase, type InputBaseProps, AddressInput, type AddressInputProps } from "./Input";
-export { EtherInput, type EtherInputProps } from "./EtherInput";
+export {
+  InputBase,
+  type InputBaseProps,
+  AddressInput,
+  type AddressInputProps,
+  EtherInput,
+  type EtherInputProps,
+} from "./Input";

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,8 +1,8 @@
 export { Address, type AddressProps } from "./Address";
 export { Balance, type BalanceProps } from "./Balance";
 export {
-  InputBase,
-  type InputBaseProps,
+  BaseInput,
+  type BaseInputProps,
   AddressInput,
   type AddressInputProps,
   EtherInput,


### PR DESCRIPTION
Update InputBase component. Main change - colors prop:
```
  colors?: {
    border: string;
    background: string;
    text: string;
  };
```
Why did I use direct colors instead of tailwind classNames? AddressInput component prefix/postfix uses these colors a bit differently. For example, border color could be used for prefix background. See my other comments.

Updated `EtherInput` so now it uses `InputBase`
Updated `AddressInput` and `EtherInput` so color prop could be passed.
Added colored examples of `AddressInput` and `EtherInput`

<details><summary>Video</summary>
<p>


https://github.com/user-attachments/assets/1f7f465e-8b95-4dc0-9bff-d89459e58742


</p>
</details> 

---

One question, not sure if we need to change name of this component to `BaseInput` so it will be consistent with `AddressInput` and `EtherInput`.