### PR TITLE
fix: address component not resolving ens and avatar

### DIFF
--- a/.changeset/happy-rings-greet.md
+++ b/.changeset/happy-rings-greet.md
@@ -1,0 +1,5 @@
+---
+"@scaffold-ui/hooks": patch
+---
+
+fix: useAddress to only use mainnet for resolving ens

--- a/packages/hooks/src/useAddress.ts
+++ b/packages/hooks/src/useAddress.ts
@@ -25,10 +25,19 @@ export const useAddress = (UseAddressOptions: UseAddressOptions) => {
 
   const { data: ens, isLoading: isEnsNameLoading } = useEnsName({
     address: checkSumAddress,
+    chainId: 1,
+    query: {
+      enabled: isAddress(checkSumAddress ?? ""),
+    },
   });
 
   const { data: ensAvatar } = useEnsAvatar({
     name: ens ? normalize(ens) : undefined,
+    chainId: 1,
+    query: {
+      enabled: Boolean(ens),
+      gcTime: 30_000,
+    },
   });
 
   const shortAddress = checkSumAddress ? `${checkSumAddress.slice(0, 6)}...${checkSumAddress.slice(-4)}` : undefined;


### PR DESCRIPTION
## Description: 

Fixes #16 


https://github.com/user-attachments/assets/b8b06f85-2890-4e6a-83b3-9c543f42298a


The problem was since in SE-2 wagmi config the first chain configured was hardhat it was by default using hardhat chain to talk with ens universal resolution contract (which is not preset).  Also the problem was not fetching ens slow but it was not able resolve only. 

### To test: 

You can follow this instruction https://github.com/scaffold-eth/scaffold-ui#testing-packages-with-scaffold-eth-2-locally with this pr branch: https://github.com/scaffold-eth/scaffold-eth-2/pull/1136



