### PR TITLE
next iteration UI polish tweaks

### DIFF
--- a/packages/components/src/Input/BaseInput.tsx
+++ b/packages/components/src/Input/BaseInput.tsx
@@ -86,7 +86,7 @@ export const BaseInput = <T extends { toString: () => string } | undefined = str
     >
       {prefix}
       <input
-        className={`w-full h-[2.2rem] min-h-[2.2rem] px-4 border-0 bg-transparent font-medium focus:outline-none focus:ring-0 ${
+        className={`w-full h-[2.2rem] min-h-[2.2rem] px-4 border-0 bg-transparent font-medium text-sm focus:outline-none focus:ring-0 ${
           disabled ? "cursor-not-allowed" : ""
         }`}
         placeholder={placeholder}

--- a/packages/components/src/Input/EtherInput.tsx
+++ b/packages/components/src/Input/EtherInput.tsx
@@ -113,7 +113,7 @@ export const EtherInput = ({
                   : "Toggle USD/ETH"
             }
           >
-            <SwitchIcon width={16} height={16} />
+            <SwitchIcon height={15} width={15} />
           </button>
         }
       />

--- a/packages/components/src/styles.css
+++ b/packages/components/src/styles.css
@@ -32,7 +32,8 @@
   --color-sui-primary-neutral: #2a3655;
   --color-sui-primary-content: #f9fbff;
 
-  --color-sui-input-text: var(--color-sui-primary-content);
+  --color-sui-input-text: color-mix(in srgb, var(--color-sui-primary-content) 70%, transparent);
+  --color-sui-input-border: var(--color-sui-primary);
 }
 
 .skeleton {

--- a/packages/components/src/styles.css
+++ b/packages/components/src/styles.css
@@ -33,6 +33,7 @@
   --color-sui-primary-content: #f9fbff;
 
   --color-sui-input-text: color-mix(in srgb, var(--color-sui-primary-content) 70%, transparent);
+  --color-sui-input-border-disabled: var(--color-sui-primary);
   --color-sui-input-border: var(--color-sui-primary);
 }
 


### PR DESCRIPTION
### Description: 

Marking this as darft and will be upading it as I work on https://github.com/scaffold-eth/scaffold-eth-2/pull/1136 (will merge after decent amount of changes and create new PR)

### Updates: 

#### BaseInput updates: 
| Before | After | 
| ------- | ----- | 
| <img width="346" height="170" alt="image" src="https://github.com/user-attachments/assets/ea709cf2-42ad-4f6d-a482-935eb2af8c9a" /> | <img width="283" height="163" alt="image" src="https://github.com/user-attachments/assets/e5f69a91-e2bc-4666-a676-e1ec08d11f0b" /> | 

Made the font a bit shorter (similar to SE-2) and added a border in dark mode; previously it was not present. 
