### PR TITLE
Add horizontal scroll to vars on debug page

### DIFF
--- a/packages/debug-contracts/src/Contract.tsx
+++ b/packages/debug-contracts/src/Contract.tsx
@@ -35,7 +35,7 @@ export const Contract: React.FC<ContractProps> = ({ contractName, contract, chai
                 </div>
               </div>
             </div>
-            <div className="bg-sui-primary-subtle dark:bg-sui-primary rounded-3xl px-6 lg:px-8 py-4 shadow-lg shadow-sui-primary-subtle dark:shadow-sui-primary">
+            <div className="bg-sui-primary-subtle dark:bg-sui-primary rounded-3xl px-6 lg:px-8 py-4 shadow-lg shadow-sui-primary-subtle dark:shadow-sui-primary overflow-y-auto">
               <ContractVariables
                 refreshDisplayVariables={refreshDisplayVariables}
                 contract={contract}

--- a/packages/debug-contracts/src/components/DisplayVariable.tsx
+++ b/packages/debug-contracts/src/components/DisplayVariable.tsx
@@ -73,7 +73,7 @@ export const DisplayVariable = ({
       <div className="text-sui-primary-content/80 flex flex-col items-start">
         <div>
           <div
-            className={`break-all block transition bg-transparent ${
+            className={`block transition bg-transparent ${
               showAnimation ? "bg-warning rounded-xs animate-pulse-fast" : ""
             }`}
           >


### PR DESCRIPTION
Now we can scroll variables

https://github.com/user-attachments/assets/31528572-8b5a-4e1f-a003-11ddda663205

One thing that could be also updated is to make that "Divide by 1e18" tooltip to be out of the parent div so its width won't be counted, but I couldn't find the way to make it easily. I think it's ok to keep it as is

Fixes #44 
