### PR TITLE
added textSize property to BaseInput, EtherInput, AddressInput. added…

### DIFF
--- a/docs/pages/components/AddressInput.mdx
+++ b/docs/pages/components/AddressInput.mdx
@@ -27,6 +27,7 @@ import { AddressInput } from "@scaffold-ui/components";
 | `placeholder` | `string`                             | -       | Placeholder text for the input.                                                       |
 | `disabled`    | `boolean`                            | `false` | Disables the input. While resolving ENS, the input is temporarily disabled.           |
 | `style`       | `CSSProperties`                      | -       | Custom CSS styles (memoize to prevent re-renders)                                     |
+| `textSize`    | `"xs" \| "sm" \| "base" \| "lg" \| "xl" \| "2xl"` | `"base"` | Text size for the input field.                                                        |
 
 ## Live Examples
 

--- a/docs/pages/components/BaseInput.mdx
+++ b/docs/pages/components/BaseInput.mdx
@@ -31,6 +31,7 @@ import { BaseInput } from "@scaffold-ui/components";
 | `suffix`      | `ReactNode`               | -           | Element rendered after the input (e.g., a button or icon).                               |
 | `reFocus`     | `boolean`                 | -           | When `true`, auto-focuses the input and positions cursor at the end. Useful for programmatic focus. |
 | `style`       | `CSSProperties`           | -           | Custom inline styles for the input container.                                            |
+| `textSize`    | `"xs" \| "sm" \| "base" \| "lg" \| "xl" \| "2xl"` | `"base"` | Text size for the input field.                                                           |
 
 ## Live Examples
 

--- a/docs/pages/components/EtherInput.mdx
+++ b/docs/pages/components/EtherInput.mdx
@@ -27,6 +27,7 @@ import { EtherInput } from "@scaffold-ui/components";
 | `disabled`       | `boolean`                                                                              | `false` | Disables the input and toggle button                                                                     |
 | `onValueChange`  | `(value: { valueInEth: string; valueInUsd: string; displayUsdMode: boolean }) => void` | -       | Called when the value or display mode changes. Provides both ETH and USD values and current display mode |
 | `style`          | `CSSProperties`                                                                        | -       | Custom CSS styles (memoize to prevent re-renders)                                                        |
+| `textSize`       | `"xs" \| "sm" \| "base" \| "lg" \| "xl" \| "2xl"`                                      | `"base"` | Text size for the input field.                                                                           |
 
 ## Live Examples
 

--- a/packages/components/src/Input/AddressInput.tsx
+++ b/packages/components/src/Input/AddressInput.tsx
@@ -3,11 +3,13 @@
 import { blo } from "blo";
 import { Address } from "viem";
 import { useAddressInput } from "@scaffold-ui/hooks";
-import { BaseInput } from "./BaseInput";
+import { BaseInput, TextSize } from "./BaseInput";
 import { CommonInputProps } from "./utils";
 import { useEffect, useState } from "react";
 
-export type AddressInputProps = CommonInputProps<Address | string>;
+export type AddressInputProps = CommonInputProps<Address | string> & {
+  textSize?: TextSize;
+};
 
 /**
  * AddressInput Component
@@ -28,6 +30,7 @@ export type AddressInputProps = CommonInputProps<Address | string>;
  * @param {boolean} [props.disabled] - (Optional) Whether the input is disabled.
  * @param {CSSProperties} [props.style] - (Optional) Custom CSS styles to apply to the component.
  *   Performance Warning: Always memoize style objects to prevent unnecessary re-renders.
+ * @param {TextSize} [props.textSize] - (Optional) Text size for the input. Accepts "xs", "sm", "base", "lg", "xl", or "2xl". Defaults to "base".
  *
  * @example
  * const [value, setValue] = useState<string>("vitalik.eth");
@@ -39,7 +42,7 @@ export type AddressInputProps = CommonInputProps<Address | string>;
  * />
 
  */
-export const AddressInput = ({ value, name, placeholder, onChange, disabled, style }: AddressInputProps) => {
+export const AddressInput = ({ value, name, placeholder, onChange, disabled, style, textSize }: AddressInputProps) => {
   const {
     ensAddress,
     ensName,
@@ -81,6 +84,7 @@ export const AddressInput = ({ value, name, placeholder, onChange, disabled, sty
       style={style}
       disabled={isEnsAddressLoading || isEnsNameLoading || disabled}
       reFocus={reFocus}
+      textSize={textSize}
       prefix={
         ensName ? (
           <div

--- a/packages/components/src/Input/BaseInput.tsx
+++ b/packages/components/src/Input/BaseInput.tsx
@@ -4,11 +4,14 @@ import { ChangeEvent, FocusEvent, ReactNode, useCallback, useEffect, useRef } fr
 import { CommonInputProps } from "./utils";
 import { DefaultStylesWrapper } from "../utils/ComponentWrapper";
 
+export type TextSize = "xs" | "sm" | "base" | "lg" | "xl" | "2xl";
+
 export type BaseInputProps<T> = CommonInputProps<T> & {
   error?: boolean;
   prefix?: ReactNode;
   suffix?: ReactNode;
   reFocus?: boolean;
+  textSize?: TextSize;
 };
 
 /**
@@ -33,6 +36,7 @@ export type BaseInputProps<T> = CommonInputProps<T> & {
  * @param {boolean} [props.reFocus] - (Optional) If true, input auto-focuses and cursor moves to end.
  * @param {CSSProperties} [props.style] - (Optional) Custom CSS styles to apply to the component.
  *   Performance Warning: Always memoize style objects to prevent unnecessary re-renders.
+ * @param {TextSize} [props.textSize] - (Optional) Text size for the input. Accepts "xs", "sm", "base", "lg", "xl", or "2xl". Defaults to "base".
  *
  * @example
  * <BaseInput
@@ -55,6 +59,7 @@ export const BaseInput = <T extends { toString: () => string } | undefined = str
   suffix,
   reFocus,
   style,
+  textSize = "base",
 }: BaseInputProps<T>) => {
   const inputReft = useRef<HTMLInputElement>(null);
 
@@ -90,7 +95,7 @@ export const BaseInput = <T extends { toString: () => string } | undefined = str
     >
       {prefix}
       <input
-        className={`w-full h-[2.2rem] min-h-[2.2rem] px-4 border-0 bg-transparent font-medium placeholder:text-sui-accent/70 focus:text-sui-input-text text-sui-input-text disabled:text-sui-base-content/40 text-sm focus:outline-none focus:ring-0 ${
+        className={`w-full h-[2.2rem] min-h-[2.2rem] px-4 border-0 bg-transparent font-medium placeholder:text-sui-accent/70 focus:text-sui-input-text text-sui-input-text disabled:text-sui-base-content/40 text-${textSize} focus:outline-none focus:ring-0 ${
           disabled ? "cursor-not-allowed" : ""
         }`}
         placeholder={placeholder}

--- a/packages/components/src/Input/EtherInput.tsx
+++ b/packages/components/src/Input/EtherInput.tsx
@@ -3,13 +3,14 @@
 import { useEffect, useRef, useState } from "react";
 import { MAX_DECIMALS_USD, useEtherInput, SIGNED_NUMBER_REGEX } from "@scaffold-ui/hooks";
 import { SwitchIcon } from "../icons/SwitchIcon";
-import { BaseInput } from "./BaseInput";
+import { BaseInput, TextSize } from "./BaseInput";
 import { CommonInputProps } from "./utils";
 
 export type EtherInputProps = Omit<CommonInputProps<string>, "onChange" | "value"> & {
   defaultValue?: string;
   defaultUsdMode?: boolean;
   onValueChange?: (value: { valueInEth: string; valueInUsd: string; displayUsdMode: boolean }) => void;
+  textSize?: TextSize;
 };
 
 /**
@@ -30,6 +31,7 @@ export type EtherInputProps = Omit<CommonInputProps<string>, "onChange" | "value
  * @param {(value: { valueInEth: string; valueInUsd: string; usdMode: boolean }) => void} props.onValueChange - (Optional) Callback fired when the value or mode changes.
  * @param {CSSProperties} [props.style] - (Optional) Custom CSS styles to apply to the component.
  *   Performance Warning: Always memoize style objects to prevent unnecessary re-renders.
+ * @param {TextSize} [props.textSize] - (Optional) Text size for the input. Accepts "xs", "sm", "base", "lg", "xl", or "2xl". Defaults to "base".
  *
  * @example
  * <EtherInput onValueChange={({ valueInEth, valueInUsd, usdMode }) => { ... }} />
@@ -43,6 +45,7 @@ export const EtherInput = ({
   disabled,
   onValueChange,
   style,
+  textSize,
 }: EtherInputProps) => {
   const [sourceValue, setSourceValue] = useState(defaultValue ?? "");
   const [sourceUsdMode, setSourceUsdMode] = useState(defaultUsdMode ?? false);
@@ -96,6 +99,7 @@ export const EtherInput = ({
         disabled={isNativeCurrencyPriceLoading || disabled}
         prefix={<span className="pl-4 -mr-2 self-center">{displayUsdMode ? "$" : "Ξ"}</span>}
         style={style}
+        textSize={textSize}
         suffix={
           <button
             className="h-[2.2rem] min-h-[2.2rem] cursor-pointer mr-3"

--- a/packages/components/src/Input/index.ts
+++ b/packages/components/src/Input/index.ts
@@ -1,3 +1,3 @@
-export { BaseInput, type BaseInputProps } from "./BaseInput.js";
+export { BaseInput, type BaseInputProps, type TextSize } from "./BaseInput.js";
 export { AddressInput, type AddressInputProps } from "./AddressInput.js";
 export { EtherInput, type EtherInputProps } from "./EtherInput.js";


### PR DESCRIPTION
Fixes #79 

- Added a textSize prop to BaseInput, AddressInput, and EtherInput components
- Allows customizing the font size of the input text using Tailwind's text size scale

## Changes

- BaseInput.tsx: Added TextSize type and textSize prop that applies text-{size} class to the input element
- AddressInput.tsx: Added textSize prop, passed through to BaseInput
- EtherInput.tsx: Added textSize prop, passed through to BaseInput
- Input/index.ts: Exported TextSize type for consumers
- Documentation: Updated props tables for all three components

## Props

Value | Description
-- | --
xs | Extra small
sm | Small
base | Base (default)
lg | Large
xl | Extra large
2xl | 2x large

## Usage

```
<BaseInput textSize="lg" placeholder="Large text" />
<AddressInput textSize="sm" placeholder="Small text" />
<EtherInput textSize="xl" placeholder="Extra large" />
```