### PR TITLE
Fix wrong block explorer links in Contract and local chain fallback

### DIFF
--- a/.changeset/short-wings-cough.md
+++ b/.changeset/short-wings-cough.md
@@ -1,0 +1,7 @@
+---
+"@scaffold-ui/debug-contracts": patch
+"@scaffold-ui/components": patch
+"@scaffold-ui/hooks": patch
+---
+
+Fix wrong block explorer links in Contract and local chain fallback

--- a/README.md
+++ b/README.md
@@ -26,13 +26,17 @@ cd packages/hooks && pnpm run dev &
 
 # For components
 cd packages/components && pnpm run dev &
+
+# For debug-contracts
+cd packages/debug-contracts && pnpm run dev &
 ```
 
-2. Add both packages in Scaffold-ETH 2 inside the `packages/nextjs/package.json` file:
+2. Add packages in Scaffold-ETH 2 inside the `packages/nextjs/package.json` file:
 
 ```json
 "@scaffold-ui/hooks": "file:../../../scaffold-ui/packages/hooks",
-"@scaffold-ui/components": "file:../../../scaffold-ui/packages/components"
+"@scaffold-ui/components": "file:../../../scaffold-ui/packages/components",
+"@scaffold-ui/debug-contracts": "file:../../../scaffold-ui/packages/debug-contracts",
 ```
 
 **Note:** The relative paths use `../../../` because they are resolved from the `packages/nextjs` directory in Scaffold-ETH 2's workspace structure.
@@ -54,13 +58,7 @@ webpack: (config, { dev }) => {
 },
 ```
 
-4. Add the css file in `packages/nextjs/app/layout.tsx` file for the components package:
-
-```tsx
-import "@scaffold-ui/components/styles.css";
-```
-
-5. Install dependencies in Scaffold-ETH 2:
+4. Install dependencies in Scaffold-ETH 2:
 
 ```bash
 yarn install

--- a/docs/pages/debug-contracts/Contract.mdx
+++ b/docs/pages/debug-contracts/Contract.mdx
@@ -23,7 +23,7 @@ import { Contract } from "@scaffold-ui/debug-contracts";
 | `contractName`             | `string`                         | -           | The name of the contract to display              |
 | `contract`                 | `{ address: Address, abi: Abi }` | -           | The abi and address of the contract to display   |
 | `chainId`                  | `number`                         | -           | The chain ID where the contract is deployed      |
-| `blockExplorerAddressLink` | `string`                         | `undefined` | The block explorer link for the contract address |
+| `blockExplorerBaseUrl`     | `string`                         | `undefined` | Base URL of the block explorer. The component appends `/address/{addr}` per rendered address. Defaults to `/blockexplorer` for local chain (31337) and to the chain's configured explorer otherwise. |
 
 ## Live Example:
 

--- a/packages/components/src/Address/AddressLinkWrapper.tsx
+++ b/packages/components/src/Address/AddressLinkWrapper.tsx
@@ -3,7 +3,7 @@ import React from "react";
 type AddressLinkWrapperProps = {
   children: React.ReactNode;
   disableAddressLink?: boolean;
-  blockExplorerAddressLink: string;
+  blockExplorerAddressLink?: string;
 };
 
 export const AddressLinkWrapper = ({
@@ -11,13 +11,14 @@ export const AddressLinkWrapper = ({
   disableAddressLink,
   blockExplorerAddressLink,
 }: AddressLinkWrapperProps) => {
-  return disableAddressLink ? (
-    <>{children}</>
-  ) : (
+  if (disableAddressLink || !blockExplorerAddressLink) {
+    return <>{children}</>;
+  }
+  const isRelative = blockExplorerAddressLink.startsWith("/");
+  return (
     <a
       href={blockExplorerAddressLink}
-      target="_blank"
-      rel="noopener noreferrer"
+      {...(isRelative ? {} : { target: "_blank", rel: "noopener noreferrer" })}
     >
       {children}
     </a>

--- a/packages/debug-contracts/README.md
+++ b/packages/debug-contracts/README.md
@@ -18,7 +18,7 @@ pnpm add @scaffold-ui/components @scaffold-ui/hooks @scaffold-ui/debug-contracts
 
 - `contracts` (required): An object containing deployed contracts organized by chain ID, where each contract includes address and ABI
 - `chainId` (required): The chain ID to use for debugging contracts (number)
-- `blockExplorerAddressLink` (optional): The block explorer link for the contract address
+- `blockExplorerBaseUrl` (optional): Base URL of the block explorer. The component appends `/address/{addr}` per rendered address. Defaults to `/blockexplorer` for local chain (31337) and to the chain's configured explorer otherwise.
 
 ## Usage
 

--- a/packages/debug-contracts/src/Contract.tsx
+++ b/packages/debug-contracts/src/Contract.tsx
@@ -16,15 +16,25 @@ export type ContractProps = {
     abi: Abi;
   };
   chainId: number;
-  blockExplorerAddressLink?: string;
+  /**
+   * Optional base URL override for the block explorer. The component appends `/address/{addr}`
+   * per-rendered address. If omitted, uses the chain's default resolution (local `/blockexplorer`
+   * for chain 31337, `chain.blockExplorers.default.url` otherwise).
+   */
+  blockExplorerBaseUrl?: string;
 };
 
-export const Contract: React.FC<ContractProps> = ({ contractName, contract, chainId, blockExplorerAddressLink }) => {
+export const Contract: React.FC<ContractProps> = ({ contractName, contract, chainId, blockExplorerBaseUrl }) => {
   const [refreshDisplayVariables, triggerRefreshDisplayVariables] = useReducer((value) => !value, false);
   const chain = extractChain({
     chains: Object.values(chains),
     id: chainId as any,
   });
+
+  const resolveAddressLink = (addr: string): string | undefined => {
+    if (blockExplorerBaseUrl) return `${blockExplorerBaseUrl.replace(/\/$/, "")}/address/${addr}`;
+    return undefined;
+  };
 
   const balanceStyle = useMemo(
     () => ({
@@ -34,7 +44,7 @@ export const Contract: React.FC<ContractProps> = ({ contractName, contract, chai
   );
 
   return (
-    <ContractConfigProvider config={{ blockExplorerAddressLink, chain, chainId }}>
+    <ContractConfigProvider config={{ resolveAddressLink, chain, chainId }}>
       <div className="grid grid-cols-1 lg:grid-cols-6 px-6 lg:px-10 lg:gap-12 w-full max-w-7xl my-0 font-sans">
         <div className="col-span-5 grid grid-cols-1 lg:grid-cols-3 gap-8 lg:gap-10">
           <div className="col-span-1 flex flex-col">
@@ -47,7 +57,7 @@ export const Contract: React.FC<ContractProps> = ({ contractName, contract, chai
                     onlyEnsOrAddress
                     size="base"
                     chain={chain}
-                    blockExplorerAddressLink={blockExplorerAddressLink}
+                    blockExplorerAddressLink={resolveAddressLink(contract.address)}
                   />
                   <div className="flex gap-1 items-center mt-1">
                     <span className="font-bold text-sm">Balance:</span>

--- a/packages/debug-contracts/src/contexts/ContractConfigContext.tsx
+++ b/packages/debug-contracts/src/contexts/ContractConfigContext.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, ReactNode } from "react";
 import { Chain } from "viem";
 
 export type ContractConfig = {
-  blockExplorerAddressLink?: string;
+  resolveAddressLink?: (address: string) => string | undefined;
   chain: Chain;
   chainId: number;
 };

--- a/packages/debug-contracts/src/utils/utilsDisplay.tsx
+++ b/packages/debug-contracts/src/utils/utilsDisplay.tsx
@@ -22,14 +22,14 @@ type DisplayContent =
 type ResultFontSize = "sm" | "base" | "xs" | "lg" | "xl" | "2xl" | "3xl";
 
 const AddressWithConfig = ({ address, size }: { address: string; size: ResultFontSize }) => {
-  const { chain, blockExplorerAddressLink } = useContractConfig();
+  const { chain, resolveAddressLink } = useContractConfig();
   return (
     <Address
       address={address as `0x${string}`}
       size={size}
       onlyEnsOrAddress
       chain={chain}
-      blockExplorerAddressLink={blockExplorerAddressLink}
+      blockExplorerAddressLink={resolveAddressLink?.(address)}
     />
   );
 };

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,4 +1,4 @@
-export { useAddress } from "./useAddress.js";
+export { useAddress, getBlockExplorerAddressLink } from "./useAddress.js";
 export { useAddressInput } from "./useAddressInput.js";
 export { useBalance, useWatchBalance } from "./balance/index.js";
 export { useFetchNativeCurrencyPrice } from "./useFetchNativeCurrencyPrice.js";

--- a/packages/hooks/src/useAddress.ts
+++ b/packages/hooks/src/useAddress.ts
@@ -13,7 +13,8 @@ export function getBlockExplorerAddressLink(network: Chain, address: string) {
   const blockExplorerBaseURL = network.blockExplorers?.default?.url;
 
   if (!blockExplorerBaseURL) {
-    return `https://etherscan.io/address/${address}`;
+    if (network.id === 31337) return `/blockexplorer/address/${address}`;
+    return "";
   }
 
   return `${blockExplorerBaseURL}/address/${address}`;


### PR DESCRIPTION
## Before

Two bugs in `<Contract>` block explorer behavior:

1. **Local chain (foundry/hardhat) addresses linked to etherscan.** `useAddress`'s `getBlockExplorerAddressLink` fell back to `https://etherscan.io/address/...` whenever a chain had no `blockExplorers.default.url`. Local nodes have none, so every address pointed at etherscan.

2. **Same `blockExplorerAddressLink` applied to every address rendered inside `<Contract>`.** The prop was a fixed URL string built around the *contract's* address, but `<Contract>` forwards it through `ContractConfigContext` to every nested `<Address>` (in `ContractVariables`, read-method results, etc.). Distinct addresses ended up sharing one link.

## After

- `getBlockExplorerAddressLink` (in `@scaffold-ui/hooks`) no longer falls back to etherscan. For chain `31337` it returns the relative `/blockexplorer/address/{addr}` (the SE-2 local explorer route); for any chain with no explorer configured it returns `""` (rendered as plain text — no broken link).
- New helper exported from `@scaffold-ui/hooks`: `getBlockExplorerAddressLink(chain, addr)`.
- `AddressLinkWrapper` no longer renders an `<a>` with an empty `href`. Relative URLs (`/...`) open in the same tab; absolute URLs keep `target="_blank"` + `rel="noopener noreferrer"`.
- `<Contract>` prop renamed `blockExplorerAddressLink` → `blockExplorerBaseUrl` (**breaking**). It's now a *base URL* — the component appends `/address/{addr}` per rendered address, with trailing `/` stripped. Defaults handle local chain and chains with explorers automatically; pass the prop only to override.

## Breaking changes

- `<Contract blockExplorerAddressLink>` → `<Contract blockExplorerBaseUrl>` (and semantics: full URL → base URL).
- `getBlockExplorerAddressLink` returns `""` instead of an etherscan URL when a chain has no explorer.

## How to test

1. Run SE-2 app with these changes. See README for how to do it, or just run SE-2 from [this branch](https://github.com/scaffold-eth/scaffold-eth-2/pull/1275). Change relative urls in `package.json` if needed.
2. In an SE-2 project (or the `example/` app) running on hardhat:
   - Render `<Contract contractName="..." contract={{ address, abi }} chainId={31337} />` with no `blockExplorerBaseUrl` prop.
   - Click the contract header address → opens `/blockexplorer/address/{contractAddress}` in the same tab.
   - Inside `ContractVariables` / read methods, click distinct returned addresses → each opens its own `/blockexplorer/address/{thatAddress}`.
3. Switch network to a chain with an explorer (e.g. sepolia):
   - Each address links to `https://sepolia.etherscan.io/address/{addr}` in a new tab.
4. Pass an override: `<Contract ... blockExplorerBaseUrl="https://custom.xyz" />` → addresses open at `https://custom.xyz/address/{addr}`.
5. Pass a chain with no explorer and chain id ≠ 31337 → addresses render as plain text (no link). Use any of the chains below to test

```
Devnets / testnets
  - chips
  - humanodeTestnet5                                                                                   
  - hyperliquidEvmTestnet
  - lumozTestnet                                                                                       
  - otimDevnet               
  - plasmaDevnet
                
  Searched node_modules/viem/chains/definitions/ (639 files) for ones missing the blockExplorers field.
```

Closes #100
