### PR TITLE
feat: agent discoverability infra (robots, sitemap, agent-skills index, Link header)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules
 .pnpm-store/
 .pnpm-debug.log
+
+# Generated at build time by docs/scripts/gen-sitemap.ts (see docs/vocs.config.ts)
+docs/public/sitemap.xml

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ node_modules
 
 # Generated at build time by docs/scripts/gen-sitemap.ts (see docs/vocs.config.ts)
 docs/public/sitemap.xml
+
+# Generated at build time by docs/scripts/gen-agent-skills-index.ts
+docs/public/.well-known/

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,67 @@
+# Scaffold UI documentation is open-source and intended to be
+# discoverable by search engines and AI agents. Crawl freely.
+
+User-agent: *
+Allow: /
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
+
+# AI training and search crawlers — explicitly allowed so agents can
+# index Scaffold UI components, hooks, and recipes.
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: Claude-User
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Googlebot
+Allow: /
+
+User-agent: Applebot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: Meta-ExternalAgent
+Allow: /
+
+User-agent: FacebookBot
+Allow: /
+
+User-agent: cohere-ai
+Allow: /
+
+User-agent: MistralAI-User
+Allow: /
+
+Sitemap: https://ui.scaffoldeth.io/sitemap.xml

--- a/docs/scripts/gen-agent-skills-index.ts
+++ b/docs/scripts/gen-agent-skills-index.ts
@@ -1,0 +1,101 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+const SCHEMA_URL = "https://schemas.agentskills.io/discovery/0.2.0/schema.json";
+const ROOT_SKILL = "public/SKILL.md";
+const SKILLS_DIR = "public/skills";
+const OUTPUT = "public/.well-known/agent-skills/index.json";
+const PRODUCTION_URL = "https://ui.scaffoldeth.io";
+
+type SkillType = "skill-md" | "archive";
+
+type SkillEntry = {
+  name: string;
+  type: SkillType;
+  description: string;
+  url: string;
+  digest: string;
+};
+
+function resolveBaseUrl(): string {
+  if (process.env.VERCEL_ENV === "production" && process.env.VERCEL_PROJECT_PRODUCTION_URL) {
+    return `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`;
+  }
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+  return PRODUCTION_URL;
+}
+
+function sha256Digest(filePath: string): string {
+  const buf = fs.readFileSync(filePath);
+  return `sha256:${crypto.createHash("sha256").update(buf).digest("hex")}`;
+}
+
+function parseFrontmatter(source: string): Record<string, string> {
+  const match = source.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return {};
+  const body = match[1];
+  const out: Record<string, string> = {};
+  for (const line of body.split(/\r?\n/)) {
+    const kv = line.match(/^([a-zA-Z0-9_-]+):\s*(.*)$/);
+    if (!kv) continue;
+    let value = kv[2].trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    out[kv[1]] = value;
+  }
+  return out;
+}
+
+function buildEntry(filePath: string, routePath: string, fallbackName: string, baseUrl: string): SkillEntry | null {
+  if (!fs.existsSync(filePath)) return null;
+  const source = fs.readFileSync(filePath, "utf8");
+  const fm = parseFrontmatter(source);
+  const name = (fm.name || fallbackName).toLowerCase();
+  const description = fm.description || `${name} skill for Scaffold UI`;
+
+  return {
+    name,
+    type: "skill-md",
+    description,
+    url: `${baseUrl}${routePath}`,
+    digest: sha256Digest(filePath),
+  };
+}
+
+let generated = false;
+
+export function generateAgentSkillsIndex(): void {
+  if (generated) return;
+  generated = true;
+
+  const baseUrl = resolveBaseUrl();
+  const entries: SkillEntry[] = [];
+
+  const root = buildEntry(ROOT_SKILL, "/SKILL.md", "scaffold-ui", baseUrl);
+  if (root) entries.push(root);
+
+  if (fs.existsSync(SKILLS_DIR)) {
+    for (const dir of fs.readdirSync(SKILLS_DIR, { withFileTypes: true })) {
+      if (!dir.isDirectory()) continue;
+      const skillFile = path.join(SKILLS_DIR, dir.name, "SKILL.md");
+      const entry = buildEntry(skillFile, `/skills/${dir.name}/SKILL.md`, dir.name, baseUrl);
+      if (entry) entries.push(entry);
+    }
+  }
+
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+
+  const index = {
+    $schema: SCHEMA_URL,
+    skills: entries,
+  };
+
+  fs.mkdirSync(path.dirname(OUTPUT), { recursive: true });
+  fs.writeFileSync(OUTPUT, JSON.stringify(index, null, 2) + "\n");
+
+  console.log(`✅ Generated agent-skills index with ${entries.length} skills (base: ${baseUrl})`);
+}

--- a/docs/scripts/gen-sitemap.ts
+++ b/docs/scripts/gen-sitemap.ts
@@ -1,0 +1,93 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const PAGES_DIR = "pages";
+const OUTPUT = "public/sitemap.xml";
+
+const PRODUCTION_URL = "https://ui.scaffoldeth.io";
+
+function resolveBaseUrl(): string {
+  if (process.env.VERCEL_ENV === "production" && process.env.VERCEL_PROJECT_PRODUCTION_URL) {
+    return `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`;
+  }
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+  return PRODUCTION_URL;
+}
+
+function collectRoutes(dir: string, basePath = ""): string[] {
+  const routes: string[] = [];
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const { name } = entry;
+    if (name.startsWith("_") || name.startsWith(".")) continue;
+
+    const full = path.join(dir, name);
+
+    if (entry.isDirectory()) {
+      routes.push(...collectRoutes(full, `${basePath}/${name}`));
+      continue;
+    }
+
+    if (!/\.(md|mdx)$/.test(name)) continue;
+
+    const bare = name.replace(/\.(md|mdx)$/, "");
+    const route = bare === "index" ? basePath || "/" : `${basePath}/${bare}`;
+    routes.push(route);
+  }
+
+  return routes;
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function toXml(routes: string[], baseUrl: string): string {
+  const lastmod = new Date().toISOString().slice(0, 10);
+
+  const urls = [...routes]
+    .sort()
+    .map((route) => {
+      const loc = escapeXml(route === "/" ? baseUrl : `${baseUrl}${route}`);
+      const priority = route === "/" ? "1.0" : "0.8";
+      return [
+        "  <url>",
+        `    <loc>${loc}</loc>`,
+        `    <lastmod>${lastmod}</lastmod>`,
+        `    <changefreq>weekly</changefreq>`,
+        `    <priority>${priority}</priority>`,
+        "  </url>",
+      ].join("\n");
+    })
+    .join("\n");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`;
+}
+
+let generated = false;
+
+export function generateSitemap(): void {
+  if (generated) return;
+  generated = true;
+
+  if (!fs.existsSync(PAGES_DIR)) {
+    console.warn(`⚠️  ${PAGES_DIR} not found — skipping sitemap generation`);
+    return;
+  }
+
+  const baseUrl = resolveBaseUrl();
+  const routes = collectRoutes(PAGES_DIR);
+  const xml = toXml(routes, baseUrl);
+
+  fs.mkdirSync(path.dirname(OUTPUT), { recursive: true });
+  fs.writeFileSync(OUTPUT, xml);
+
+  console.log(`✅ Generated sitemap.xml with ${routes.length} URLs (base: ${baseUrl})`);
+}

--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -1,11 +1,13 @@
 import { defineConfig } from "vocs";
 import { fileURLToPath } from "url";
 import { dirname, resolve } from "path";
+import { generateAgentSkillsIndex } from "./scripts/gen-agent-skills-index";
 import { generateSitemap } from "./scripts/gen-sitemap";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 generateSitemap();
+generateAgentSkillsIndex();
 
 export default defineConfig({
   rootDir: ".",

--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -1,8 +1,11 @@
 import { defineConfig } from "vocs";
 import { fileURLToPath } from "url";
 import { dirname, resolve } from "path";
+import { generateSitemap } from "./scripts/gen-sitemap";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+generateSitemap();
 
 export default defineConfig({
   rootDir: ".",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,13 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Link",
+          "value": "</llms.txt>; rel=\"alternate\"; type=\"text/plain\"; title=\"LLM-friendly documentation index\", </llms-full.txt>; rel=\"alternate\"; type=\"text/plain\"; title=\"LLM-friendly full documentation\", </sitemap.xml>; rel=\"sitemap\"; type=\"application/xml\", </.well-known/agent-skills/index.json>; rel=\"describedby\"; type=\"application/json\"; title=\"Agent skills discovery index\""
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the discoverability infra so AI agents and crawlers can find and consume scaffold-ui docs without parsing HTML. Mirrors what we shipped for SE-2 docs in [scaffold-eth/se-2-docs#161](https://github.com/scaffold-eth/se-2-docs/pull/161). No content changes — only additions under `docs/public/`, two build-time scripts, and a `vercel.json` for response headers.

- `docs/public/robots.txt` — explicit allow-list for major AI crawlers (GPTBot, ClaudeBot, Claude-SearchBot, Claude-User, PerplexityBot, Google-Extended, Applebot-Extended, CCBot, Bytespider, Meta-ExternalAgent, MistralAI-User, cohere-ai, etc.) plus `Content-Signal: ai-train=yes, search=yes, ai-input=yes` per [draft-romm-aipref-contentsignals](https://datatracker.ietf.org/doc/draft-romm-aipref-contentsignals/) and a `Sitemap:` pointer.
- `docs/scripts/gen-sitemap.ts` — walks `docs/pages/**/*.{md,mdx}`, mirrors Vocs file-based routing (`index.md` → parent segment, casing preserved so `/components/Address` stays capitalised), emits `docs/public/sitemap.xml`. Wired into `vocs.config.ts` so it runs on every build. Picks up `VERCEL_URL` / `VERCEL_PROJECT_PRODUCTION_URL` automatically so preview deploys get correct sitemap hostnames.
- `docs/scripts/gen-agent-skills-index.ts` — emits `docs/public/.well-known/agent-skills/index.json` against `https://schemas.agentskills.io/discovery/0.2.0/schema.json`. Globs `docs/public/SKILL.md` (root) and `docs/public/skills/<name>/SKILL.md` (subdir skills), parses frontmatter, computes `sha256:{hex}` over raw bytes. **Currently emits an empty-but-valid `{ skills: [] }` index** since there's no SKILL.md yet — a follow-up PR will add the scaffold-ui skill and this script will auto-pick it up with no changes.
- `vercel.json` — adds `Link` header (RFC 8288) on every response advertising `llms.txt`, `llms-full.txt`, `sitemap.xml`, and the agent-skills index so agent crawlers discover machine-readable resources without parsing HTML. (`llms.txt` and `llms-full.txt` are already auto-generated by Vocs into `dist/` — verified by build.)
- `.gitignore` — excludes `docs/public/sitemap.xml` and `docs/public/.well-known/` since both regenerate on every build.

## Why `ai-train=yes, ai-input=yes`?

Scaffold UI is MIT-licensed OSS designed for builders to copy patterns from. Agents training on it → more builders shipping with these primitives. Agents fetching it as RAG context is a primary use case. Opting in to both aligns with the project's intent.

## Why a follow-up PR for `SKILL.md`?

Wanted to keep this PR purely structural — scripts, headers, manifests. The SKILL.md content needs a different conversation about what gotchas to actually capture (peer-dep ordering, `chain` defaulting behavior, provider wrapping order, etc.) and shouldn't gate the discoverability infra from landing.

## Test plan

- [ ] `pnpm install && pnpm build` from `docs/` — confirm `docs/dist/` contains `robots.txt`, `sitemap.xml`, `llms.txt`, `llms-full.txt`, and `.well-known/agent-skills/index.json`
- [ ] `xmllint --noout docs/dist/sitemap.xml` — passes
- [ ] `cat docs/dist/.well-known/agent-skills/index.json | jq .` — valid JSON, `skills: []`
- [ ] After deploy: `curl -s https://ui.scaffoldeth.io/robots.txt` contains `Content-Signal:` line
- [ ] After deploy: `curl -sI https://ui.scaffoldeth.io/ | grep -i ^link` shows four resource pointers
- [ ] After deploy: re-scan at https://isitagentready.com/ui.scaffoldeth.io — expect a meaningful jump from baseline

## Out of scope (follow-ups)

- `SKILL.md` for scaffold-ui (separate PR — currently being drafted)
- Markdown content negotiation (`Accept: text/markdown`) — agents already get full corpus via `llms-full.txt`, low ROI
- `.well-known/mcp.json`, WebMCP manifests