### PR TITLE
feat(docs): add SKILL.md for agent integration of scaffold-ui

### DIFF
--- a/docs/public/SKILL.md
+++ b/docs/public/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: scaffold-ui
+description: "Add scaffold-ui's React components and hooks (Address, Balance, AddressInput, EtherInput, BaseInput, useBalance, useAddress, useAddressInput, useEtherInput) to a Next.js or React dApp that already uses wagmi. Use this skill whenever the user wants to display Ethereum addresses with ENS resolution and blockie avatars, build address or ETH amount input fields with validation, show wallet balances with USD price conversion, add the scaffold-eth contract debugger UI to a non-SE-2 project, or integrate scaffold-eth-style UI primitives into any existing wagmi + react-query app. Also use when the user mentions scaffold-ui, @scaffold-ui/components, @scaffold-ui/hooks, or @scaffold-ui/debug-contracts by name even if they don't explicitly ask to install. This skill covers install gotchas, peer-dep ordering, provider wrapping order, the styles.css import, and the chain defaulting rule that the docs don't shout loud enough about."
+---
+
+# scaffold-ui
+
+For full API docs (every prop, every hook return value, every example), fetch https://ui.scaffoldeth.io/llms-full.txt. That's the complete docs as one file. This page covers what those docs don't shout about loud enough: the integration gotchas that bite agents when wiring scaffold-ui into a real project.
+
+## Prerequisites
+
+scaffold-ui doesn't ship its own provider stack. It expects yours. Before installing anything, verify the project has wagmi already wired:
+
+- `wagmi` (^2.14) and `viem` (^2.23) in `package.json`
+- A `WagmiProvider` somewhere in the app tree
+- A `QueryClientProvider` from `@tanstack/react-query` wrapping it
+- React 19 or newer (older versions install but break at runtime in subtle ways)
+
+If wagmi isn't set up, stop and follow https://wagmi.sh/react/getting-started first. scaffold-ui on top of an unconfigured wagmi will fail in confusing ways and the symptoms won't point at the real problem.
+
+## Install
+
+scaffold-ui ships as three separate packages. The two you almost always want:
+
+```bash
+pnpm add @scaffold-ui/components @scaffold-ui/hooks
+```
+
+`@scaffold-ui/components` peer-depends on `@scaffold-ui/hooks` because the components call into the hooks internally. Installing only components fails the build with a missing-peer error. Install both even if your code doesn't import the hooks directly.
+
+The third package, `@scaffold-ui/debug-contracts`, is opt-in. Skip it unless the user explicitly wants the SE-2 contract debugger UI in their project. It pulls in `@uniswap/sdk-core` and other deps that aren't needed for plain UI work.
+
+After installing, import the styles in your root layout (`layout.tsx` for Next App Router, `app.tsx` for Vite or CRA):
+
+```tsx
+import "@scaffold-ui/components/styles.css";
+```
+
+Forgetting this import is a silent failure mode. Components render unstyled with no console error and no visible warning. The library ships pre-built CSS so Tailwind isn't required in the consuming app, but it doesn't conflict if Tailwind is already set up.
+
+## Provider order
+
+scaffold-ui hooks read wagmi state and react-query state via context. The provider tree must wrap children in this order:
+
+```tsx
+<WagmiProvider config={wagmiConfig}>
+  <QueryClientProvider client={queryClient}>
+    {/* optional: <RainbowKitProvider> goes here if used */}
+    {children}
+  </QueryClientProvider>
+</WagmiProvider>
+```
+
+Reverse the outer two and the hooks throw on mount with either a "no QueryClient set" error or a wagmi-context error. RainbowKit, if used, must sit inside `QueryClientProvider`, not outside.
+
+For Next.js App Router, set `ssr: true` in the `createConfig` call. Without it, the first render of any scaffold-ui component hydration-mismatches between server and client:
+
+```ts
+import { createConfig, http } from "wagmi";
+import { base, mainnet, sepolia } from "viem/chains";
+
+export const wagmiConfig = createConfig({
+  chains: [base, mainnet, sepolia],
+  ssr: true,
+  client: ({ chain }) => createClient({ chain, transport: http() }),
+});
+```
+
+## The chain defaulting rule
+
+This is the gotcha that catches agents most often. Components that take a chain (Address, Balance, the input components) and hooks like `useBalance` accept an optional `chain` prop or param. When omitted, they default to **the first chain in your wagmi config**, falling back to `mainnet` only if the config has no chains at all.
+
+Don't reflexively pass `chain={mainnet}` everywhere. If the user's app primarily targets Base or Arbitrum, hardcoding mainnet means ENS resolves on the wrong network and balances fetch from the wrong chain — and the bug is invisible because something still renders. Default behavior is almost always what you want. Pass `chain` explicitly only when a specific component needs to target a network regardless of the user's config (for example, an always-mainnet ENS lookup in a multi-chain app).
+
+## Memoize the style prop
+
+Components that accept a `style` prop pass it into a memoized child. If you build the style object inline, every parent render rebuilds it, breaks memoization, and triggers a re-render cascade:
+
+```tsx
+// good — stable reference
+const addressStyle = useMemo(() => ({ fontSize: "1.5rem" }), []);
+<Address address={user} style={addressStyle} />
+
+// bad — new object every render
+<Address address={user} style={{ fontSize: "1.5rem" }} />
+```
+
+This shows up as performance degradation on pages that render many `<Address />` instances at once (lists, tables, transaction histories). Memoize once, use everywhere.
+
+## When to also install debug-contracts
+
+`@scaffold-ui/debug-contracts` ports the SE-2 contract debugger UI as a standalone React component. Install it only when:
+
+- The user explicitly asks for the SE-2 debug UI in their project
+- The user is migrating from SE-2 and wants the same dev workflow in a non-SE-2 app
+- The user is building an admin or contract debug interface
+
+Don't auto-install it just because the project has contracts. The Uniswap SDK dependency is heavy and you're paying for it on every page load.
+
+## Verify the integration
+
+Drop an `<Address />` somewhere visible:
+
+```tsx
+import { Address } from "@scaffold-ui/components";
+
+<Address address="0xd8da6bf26964af9d7eed9e03e53415d37aa96045" />;
+```
+
+If you see `vitalik.eth` with a blockie avatar and the address links to a block explorer, then install + provider order + styles import + chain config are all correct. One observable check covers the whole integration.
+
+If you see blank space or unstyled raw text, work through this list:
+
+- Unstyled text → `styles.css` import is missing from your root layout
+- "no QueryClient set" or wagmi error → provider wrapping order is wrong
+- Hydration mismatch warning → `ssr: true` is missing from `createConfig`
+- ENS not resolving → wagmi config doesn't include mainnet, or the wrong chain is being passed

--- a/docs/public/SKILL.md
+++ b/docs/public/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: scaffold-ui
-description: "Add scaffold-ui's React components and hooks (Address, Balance, AddressInput, EtherInput, BaseInput, useBalance, useAddress, useAddressInput, useEtherInput) to a Next.js or React dApp that already uses wagmi. Use this skill whenever the user wants to display Ethereum addresses with ENS resolution and blockie avatars, build address or ETH amount input fields with validation, show wallet balances with USD price conversion, add the scaffold-eth contract debugger UI to a non-SE-2 project, or integrate scaffold-eth-style UI primitives into any existing wagmi + react-query app. Also use when the user mentions scaffold-ui, @scaffold-ui/components, @scaffold-ui/hooks, or @scaffold-ui/debug-contracts by name even if they don't explicitly ask to install. This skill covers install gotchas, peer-dep ordering, provider wrapping order, the styles.css import, and the chain defaulting rule that the docs don't shout loud enough about."
+description: "Add scaffold-ui's React components and hooks (Address, Balance, useAddress, useAddressInput and etc) to a Next.js or React dApp that already uses wagmi. Use this skill whenever the user wants to display Ethereum addresses, build address or ETH amount input fields with validation, show wallet balances with USD price conversion, add the scaffold-eth contract debugger UI to a non scaffold-eth-2 project. Also use when the user mentions scaffold-ui, @scaffold-ui/components, @scaffold-ui/hooks, or @scaffold-ui/debug-contracts by name even if they don't explicitly ask to install. This skill covers install gotchas, peer-dep ordering, provider wrapping order, the styles.css import, and the chain defaulting rule."
 ---
 
 # scaffold-ui
 
-For full API docs (every prop, every hook return value, every example), fetch https://ui.scaffoldeth.io/llms-full.txt. That's the complete docs as one file. This page covers what those docs don't shout about loud enough: the integration gotchas that bite agents when wiring scaffold-ui into a real project.
+For full API docs (every prop, every hook return value, every example), fetch https://ui.scaffoldeth.io/llms-full.txt. That's the complete docs as one file. This page covers what those docs the integration gotchas that bite agents when wiring scaffold-ui into a real project.
 
 ## Prerequisites
 
@@ -16,7 +16,7 @@ scaffold-ui doesn't ship its own provider stack. It expects yours. Before instal
 - A `QueryClientProvider` from `@tanstack/react-query` wrapping it
 - React 19 or newer (older versions install but break at runtime in subtle ways)
 
-If wagmi isn't set up, stop and follow https://wagmi.sh/react/getting-started first. scaffold-ui on top of an unconfigured wagmi will fail in confusing ways and the symptoms won't point at the real problem.
+If wagmi isn't set up, stop and follow https://wagmi.sh/react/getting-started first. scaffold-ui on top of an unconfigured wagmi will fail.
 
 ## Install
 
@@ -36,7 +36,7 @@ After installing, import the styles in your root layout (`layout.tsx` for Next A
 import "@scaffold-ui/components/styles.css";
 ```
 
-Forgetting this import is a silent failure mode. Components render unstyled with no console error and no visible warning. The library ships pre-built CSS so Tailwind isn't required in the consuming app, but it doesn't conflict if Tailwind is already set up.
+Forgetting this import is a silent failure mode. The library ships pre-built CSS so Tailwind isn't required in the consuming app, but it doesn't conflict if Tailwind is already set up.
 
 ## Provider order
 
@@ -50,10 +50,6 @@ scaffold-ui hooks read wagmi state and react-query state via context. The provid
   </QueryClientProvider>
 </WagmiProvider>
 ```
-
-Reverse the outer two and the hooks throw on mount with either a "no QueryClient set" error or a wagmi-context error. RainbowKit, if used, must sit inside `QueryClientProvider`, not outside.
-
-For Next.js App Router, set `ssr: true` in the `createConfig` call. Without it, the first render of any scaffold-ui component hydration-mismatches between server and client:
 
 ```ts
 import { createConfig, http } from "wagmi";
@@ -70,7 +66,7 @@ export const wagmiConfig = createConfig({
 
 This is the gotcha that catches agents most often. Components that take a chain (Address, Balance, the input components) and hooks like `useBalance` accept an optional `chain` prop or param. When omitted, they default to **the first chain in your wagmi config**, falling back to `mainnet` only if the config has no chains at all.
 
-Don't reflexively pass `chain={mainnet}` everywhere. If the user's app primarily targets Base or Arbitrum, hardcoding mainnet means ENS resolves on the wrong network and balances fetch from the wrong chain — and the bug is invisible because something still renders. Default behavior is almost always what you want. Pass `chain` explicitly only when a specific component needs to target a network regardless of the user's config (for example, an always-mainnet ENS lookup in a multi-chain app).
+Don't reflexively pass `chain={mainnet}` everywhere. If the user's app primarily targets Base or Arbitrum, hardcoding mainnet means ENS resolves on the wrong network and balances fetch from the wrong chain. Default behavior is almost always what you want. Pass `chain` explicitly only when a specific component needs to target a network regardless of the user's config (for example, an always-mainnet ENS lookup in a multi-chain app).
 
 ## Memoize the style prop
 
@@ -89,13 +85,13 @@ This shows up as performance degradation on pages that render many `<Address />`
 
 ## When to also install debug-contracts
 
-`@scaffold-ui/debug-contracts` ports the SE-2 contract debugger UI as a standalone React component. Install it only when:
+`@scaffold-ui/debug-contracts` ports the Scaffold-ETH 2 (SE-2) contract debugger UI as a standalone React component. Install it only when:
 
 - The user explicitly asks for the SE-2 debug UI in their project
 - The user is migrating from SE-2 and wants the same dev workflow in a non-SE-2 app
 - The user is building an admin or contract debug interface
 
-Don't auto-install it just because the project has contracts. The Uniswap SDK dependency is heavy and you're paying for it on every page load.
+Don't auto-install it just because the project has contracts.
 
 ## Verify the integration
 

--- a/docs/public/SKILL.md
+++ b/docs/public/SKILL.md
@@ -5,7 +5,7 @@ description: "Add scaffold-ui's React components and hooks (Address, Balance, us
 
 # scaffold-ui
 
-For full API docs (every prop, every hook return value, every example), fetch https://ui.scaffoldeth.io/llms-full.txt. That's the complete docs as one file. This page covers what those docs the integration gotchas that bite agents when wiring scaffold-ui into a real project.
+For full API docs (every prop, every hook return value, every example), fetch https://ui.scaffoldeth.io/llms-full.txt. That's the complete docs as one file. This page covers the integration gotchas that bite agents when wiring scaffold-ui into a real project.
 
 ## Prerequisites
 
@@ -28,7 +28,7 @@ pnpm add @scaffold-ui/components @scaffold-ui/hooks
 
 `@scaffold-ui/components` peer-depends on `@scaffold-ui/hooks` because the components call into the hooks internally. Installing only components fails the build with a missing-peer error. Install both even if your code doesn't import the hooks directly.
 
-The third package, `@scaffold-ui/debug-contracts`, is opt-in. Skip it unless the user explicitly wants the SE-2 contract debugger UI in their project. It pulls in `@uniswap/sdk-core` and other deps that aren't needed for plain UI work.
+The third package, `@scaffold-ui/debug-contracts`, is opt-in. Skip it unless the user explicitly wants the SE-2 contract debugger UI in their project.
 
 After installing, import the styles in your root layout (`layout.tsx` for Next App Router, `app.tsx` for Vite or CRA):
 
@@ -57,7 +57,6 @@ import { base, mainnet, sepolia } from "viem/chains";
 
 export const wagmiConfig = createConfig({
   chains: [base, mainnet, sepolia],
-  ssr: true,
   client: ({ chain }) => createClient({ chain, transport: http() }),
 });
 ```

--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
       "headers": [
         {
           "key": "Link",
-          "value": "</llms.txt>; rel=\"alternate\"; type=\"text/plain\"; title=\"LLM-friendly documentation index\", </llms-full.txt>; rel=\"alternate\"; type=\"text/plain\"; title=\"LLM-friendly full documentation\", </sitemap.xml>; rel=\"sitemap\"; type=\"application/xml\", </.well-known/agent-skills/index.json>; rel=\"describedby\"; type=\"application/json\"; title=\"Agent skills discovery index\""
+          "value": "</llms.txt>; rel=\"alternate\"; type=\"text/plain\"; title=\"LLM-friendly documentation index\", </llms-full.txt>; rel=\"alternate\"; type=\"text/plain\"; title=\"LLM-friendly full documentation\", </SKILL.md>; rel=\"alternate\"; type=\"text/markdown\"; title=\"Agent skill for integrating scaffold-ui\", </sitemap.xml>; rel=\"sitemap\"; type=\"application/xml\", </.well-known/agent-skills/index.json>; rel=\"describedby\"; type=\"application/json\"; title=\"Agent skills discovery index\""
         }
       ]
     }


### PR DESCRIPTION
## Summary

Lands the `SKILL.md` that the discoverability infra in #104 was already designed to pick up. With this in, `https://ui.scaffoldeth.io/SKILL.md` becomes the agent-facing integration guide and `/.well-known/agent-skills/index.json` goes from `{ "skills": [] }` to a single-entry index pointing at it.

The SKILL.md is deliberately scoped to **what the docs don't shout about loud enough** — not a re-documentation of every prop and hook (those already live in `llms-full.txt`). It captures the integration gotchas that bite agents in practice:

- Peer-dep ordering between `@scaffold-ui/components` and `@scaffold-ui/hooks`
- The `styles.css` import as a silent failure mode
- Provider wrapping order (`WagmiProvider` → `QueryClientProvider` → optional `RainbowKitProvider`)
- `ssr: true` for Next.js App Router
- The chain defaulting rule (default to first chain in wagmi config, fallback mainnet) — this is the one that catches agents most often, since they reflexively pass `chain={mainnet}` everywhere
- `style` prop memoization
- When to opt into `@scaffold-ui/debug-contracts` and when to skip it

The first line of the body redirects agents to `llms-full.txt` for full API docs, so the SKILL stays focused and small (~110 lines body, well under Anthropic's 500-line guidance).

## Description field

Optimised for triggering accuracy following [Anthropic's skill-authoring best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices):

- Third person, "use when" pattern
- Lists every package name and hook name explicitly so keyword matches work
- Includes a deliberate "even if they don't explicitly ask to install" cue, since Claude tends to undertrigger skills
- ~860 chars, under the 1024 limit

## Files changed

- `docs/public/SKILL.md` (new, 117 lines including frontmatter)
- `vercel.json` (+1/-1) — adds `</SKILL.md>; rel="alternate"; type="text/markdown"` to the Link header so agents discover it on the same HEAD request as `llms.txt` and the skills index

## Test plan

- [ ] `pnpm build` from `docs/` — confirm `docs/dist/SKILL.md` exists and `docs/dist/.well-known/agent-skills/index.json` shows 1 skill entry with a valid sha256 digest
- [ ] After deploy: `curl -s https://ui.scaffoldeth.io/SKILL.md | head -5` returns the frontmatter
- [ ] After deploy: `curl -s https://ui.scaffoldeth.io/.well-known/agent-skills/index.json | jq '.skills | length'` returns `1`
- [ ] After deploy: `curl -sI https://ui.scaffoldeth.io/ | grep -i ^link` shows the new SKILL.md entry alongside the existing four
- [ ] Independent digest check: `shasum -a 256 <(curl -s https://ui.scaffoldeth.io/SKILL.md)` should match the digest in the index
- [ ] Vibe-test: hand the URL to a fresh Claude instance and ask it to integrate scaffold-ui into a Next.js app — see if it follows the gotchas

## Why this is a separate PR from #104

Kept the discoverability infra purely structural so reviewers could verify the scripts and headers in isolation. This PR is the content that flows through that infra. They could have shipped together but stacking made the diffs cleaner to review.

## Out of scope (future)

- A navigable Vocs page version of the SKILL (currently it's only the static `/SKILL.md`); could add `/build-with-ai/skill` later if humans want to read it nicely in the docs UI
- Sub-skills for specific patterns (e.g. "scaffold-ui + RainbowKit", "scaffold-ui + Privy"); the current single skill covers the integration surface