### PR TITLE
docs: restructure READMEs, add CONTRIBUTING and LICENCE

### DIFF
--- a/.changeset/readmes-and-license.md
+++ b/.changeset/readmes-and-license.md
@@ -1,0 +1,7 @@
+---
+"@scaffold-ui/components": patch
+"@scaffold-ui/hooks": patch
+"@scaffold-ui/debug-contracts": patch
+---
+
+Add MIT `license` field to package metadata and rewrite READMEs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,112 @@
+# Contributing to Scaffold UI
+
+Thanks for your interest in contributing! Bug reports, feature requests, and PRs are all welcome.
+
+## Repo layout
+
+This repo is a pnpm workspace with three published packages, a docs site, and a local example app.
+
+- `packages/components` — `@scaffold-ui/components`
+- `packages/hooks` — `@scaffold-ui/hooks`
+- `packages/debug-contracts` — `@scaffold-ui/debug-contracts`
+- `docs/` — documentation site (Vocs, deployed at [ui.scaffoldeth.io](https://ui.scaffoldeth.io))
+- `example/` — Next.js + wagmi app used to test the packages locally
+
+## Prerequisites
+
+- Node.js 20+
+- [pnpm](https://pnpm.io/installation) 10+
+
+## Setup
+
+```bash
+pnpm install
+```
+
+## Local development with the example app
+
+The fastest feedback loop. `pnpm dev` runs all three packages in watch mode and starts the example app at [http://localhost:3000](http://localhost:3000).
+
+```bash
+pnpm dev
+```
+
+Edits in `packages/*` hot-reload in the example.
+
+## Local development with Scaffold-ETH 2
+
+Use this when you need to test changes against a real Scaffold-ETH 2 project.
+
+1. From this repo, run all three packages in watch mode:
+
+   ```bash
+   cd packages/hooks && pnpm dev &
+   cd packages/components && pnpm dev &
+   cd packages/debug-contracts && pnpm dev &
+   ```
+
+2. In your Scaffold-ETH 2 repo, point `packages/nextjs/package.json` at your local checkout:
+
+   ```json
+   {
+     "dependencies": {
+       "@scaffold-ui/hooks": "file:../../../scaffold-ui/packages/hooks",
+       "@scaffold-ui/components": "file:../../../scaffold-ui/packages/components",
+       "@scaffold-ui/debug-contracts": "file:../../../scaffold-ui/packages/debug-contracts"
+     }
+   }
+   ```
+
+   The `../../../` paths assume `scaffold-ui` and your Scaffold-ETH 2 repo are siblings on disk.
+
+3. Update `packages/nextjs/next.config.js` (or `.ts`) so webpack follows symlinks in dev:
+
+   ```js
+   webpack: (config, { dev }) => {
+     config.resolve.fallback = { fs: false, net: false, tls: false };
+     config.externals.push("pino-pretty", "lokijs", "encoding");
+     if (dev) {
+       config.watchOptions = { followSymlinks: true };
+       config.snapshot.managedPaths = [];
+     }
+     return config;
+   },
+   ```
+
+4. Install and run Scaffold-ETH 2:
+
+   ```bash
+   yarn install
+   yarn chain    # one terminal
+   yarn start    # another terminal
+   ```
+
+5. After every change in `scaffold-ui`, re-run `yarn install` in Scaffold-ETH 2.
+
+## Editing docs
+
+Docs live in `docs/pages/` as MDX. Run them locally:
+
+```bash
+cd docs && pnpm dev
+```
+
+## Submitting a PR
+
+1. Fork the repo and create a branch.
+2. Make your changes. Run lint and format before committing:
+
+   ```bash
+   pnpm lint
+   pnpm format
+   ```
+
+3. If your PR changes a published package, add a [changeset](https://github.com/changesets/changesets):
+
+   ```bash
+   pnpm changeset
+   ```
+
+   Pick the affected packages, the bump type (patch/minor/major), and write a one-line summary. Skip this for docs-only or example-only changes.
+
+4. Open a PR against `main`. Once merged, the [release workflow](.github/workflows/release.yml) opens a release PR; merging that publishes to npm.

--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 BuidlGuidl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,74 +1,36 @@
 # Scaffold UI
 
-## Testing packages with local example
+React components and hooks for building Ethereum dApps. Drop them into any wagmi-based React app — no Scaffold-ETH 2 required.
 
-1. Start the dev mode of the monorepo
+**[Documentation](https://ui.scaffoldeth.io)** · **[Example app](https://scaffold-ui-example.vercel.app)** · **[Contributing](./CONTRIBUTING.md)**
 
-```bash
-pnpm dev
-```
+## Packages
 
-This will start the dev mode of both the hooks and components packages, along with the example app.
+| Package                                                      | Description                                                                                      |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| [`@scaffold-ui/components`](./packages/components)           | Pre-built React components — Address, Balance, AddressInput, EtherInput, BaseInput               |
+| [`@scaffold-ui/hooks`](./packages/hooks)                     | React hooks the components are built on — useAddress, useAddressInput, useBalance, useEtherInput |
+| [`@scaffold-ui/debug-contracts`](./packages/debug-contracts) | The Scaffold-ETH 2 contract debugger UI as a standalone component                                |
 
-2. Visit the example app at [http://localhost:3000](http://localhost:3000)
-
-3. Make changes to the packages and see them reflected in the example app
-
-## Testing packages with Scaffold-ETH 2 locally
-
-### Quick Setup
-
-1. Start the dev mode for both packages in the scaffold-ui directory:
+## Quick start
 
 ```bash
-# For hooks
-cd packages/hooks && pnpm run dev &
-
-# For components
-cd packages/components && pnpm run dev &
-
-# For debug-contracts
-cd packages/debug-contracts && pnpm run dev &
+pnpm add @scaffold-ui/components @scaffold-ui/hooks
 ```
 
-2. Add packages in Scaffold-ETH 2 inside the `packages/nextjs/package.json` file:
+```tsx
+import "@scaffold-ui/components/styles.css";
+import { Address } from "@scaffold-ui/components";
 
-```json
-"@scaffold-ui/hooks": "file:../../../scaffold-ui/packages/hooks",
-"@scaffold-ui/components": "file:../../../scaffold-ui/packages/components",
-"@scaffold-ui/debug-contracts": "file:../../../scaffold-ui/packages/debug-contracts",
+<Address address="0xd8da6bf26964af9d7eed9e03e53415d37aa96045" />;
 ```
 
-**Note:** The relative paths use `../../../` because they are resolved from the `packages/nextjs` directory in Scaffold-ETH 2's workspace structure.
+Your app needs `wagmi`, `viem`, and `@tanstack/react-query` already configured. See the [Getting Started guide](https://ui.scaffoldeth.io) for the full setup.
 
-3. Update the `webpack` section in the `next.config.js` or `next.config.ts` file:
+## Contributing
 
-```js
-webpack: (config, { dev }) => {
-  config.resolve.fallback = { fs: false, net: false, tls: false };
-  config.externals.push("pino-pretty", "lokijs", "encoding");
-  if (dev) {
-    config.watchOptions = {
-      followSymlinks: true,
-    };
+Bug reports, feature requests, and PRs welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md) for local development setup.
 
-    config.snapshot.managedPaths = [];
-  }
-  return config;
-},
-```
+## License
 
-4. Install dependencies in Scaffold-ETH 2:
-
-```bash
-yarn install
-```
-
-5. Run Scaffold-ETH 2 app:
-
-```bash
-yarn chain    # In one terminal
-yarn start    # In another terminal
-```
-
-6. Any changes in this repo will require running `yarn install` in Scaffold-ETH 2 again.
+MIT — see [LICENCE](./LICENCE).

--- a/docs/pages/debug-contracts/index.mdx
+++ b/docs/pages/debug-contracts/index.mdx
@@ -1,0 +1,61 @@
+---
+layout: docs
+---
+
+# Debug Contracts
+
+A standalone React component that ports the Scaffold-ETH 2 contract debugger UI. Drop it into any wagmi-based React app to read and write to deployed contracts during development.
+
+## Installation
+
+### Peer Dependencies
+
+Install the required peer dependencies using your preferred package manager:
+
+:::code-group
+
+```bash [npm]
+npm install react react-dom @types/react viem wagmi @tanstack/react-query
+```
+
+```bash [pnpm]
+pnpm add react react-dom @types/react viem wagmi @tanstack/react-query
+```
+
+```bash [yarn]
+yarn add react react-dom @types/react viem wagmi @tanstack/react-query
+```
+
+:::
+
+### Package Installation
+
+`@scaffold-ui/debug-contracts` peer-depends on `@scaffold-ui/components` and `@scaffold-ui/hooks`. Install all three:
+
+:::code-group
+
+```bash [npm]
+npm install @scaffold-ui/debug-contracts @scaffold-ui/components @scaffold-ui/hooks
+```
+
+```bash [pnpm]
+pnpm add @scaffold-ui/debug-contracts @scaffold-ui/components @scaffold-ui/hooks
+```
+
+```bash [yarn]
+yarn add @scaffold-ui/debug-contracts @scaffold-ui/components @scaffold-ui/hooks
+```
+
+:::
+
+### Import Styles
+
+Import the styles in your root component file (`app.tsx` for React or `layout.tsx` for Next.js):
+
+```typescript
+import "@scaffold-ui/debug-contracts/styles.css";
+```
+
+### Create wagmi config and setup Tanstack query
+
+https://wagmi.sh/react/getting-started#create-config

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -27,3 +27,5 @@ Our components are built on top of these React hooks, which you can use directly
 ## Debug Contracts
 
 **[Debug Contracts](/debug-contracts/Contract)** - A contract UI component for debugging deployed contracts.
+
+**[View Installation Guide →](/debug-contracts#installation)**

--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
     {
       text: "Debug Contracts",
       items: [
+        { text: "Installation", link: "/debug-contracts" },
         { text: "Contract", link: "/debug-contracts/Contract" },
         { text: "IntegerInput", link: "/debug-contracts/IntegerInput" },
       ],

--- a/example/README.md
+++ b/example/README.md
@@ -1,36 +1,7 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# example
 
-## Getting Started
+Local dev playground for `@scaffold-ui/*`. A minimal Next.js + wagmi + RainbowKit app used to test changes to the packages during development.
 
-First, run the development server:
+To run, see [CONTRIBUTING.md](../CONTRIBUTING.md) at the repo root.
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
-```
-
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+Live deployment: [scaffold-ui-example.vercel.app](https://scaffold-ui-example.vercel.app)

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -1,80 +1,36 @@
 # @scaffold-ui/components
 
-React components for scaffold-ui applications.
+Pre-built React components for Ethereum dApps — addresses with ENS, balances, address inputs, ETH amount inputs.
 
-## Installation
+**[Documentation](https://ui.scaffoldeth.io/components)** · [Repo](https://github.com/scaffold-eth/scaffold-ui)
 
-**Note**: This package requires `@scaffold-ui/hooks` as a peer dependency.
+## Install
 
 ```bash
-# Install both packages
 npm install @scaffold-ui/components @scaffold-ui/hooks
-
-# Or with yarn
+# or
 yarn add @scaffold-ui/components @scaffold-ui/hooks
-
-# Or with pnpm
+# or
 pnpm add @scaffold-ui/components @scaffold-ui/hooks
 ```
 
-### Peer Dependencies
+`@scaffold-ui/components` peer-depends on `@scaffold-ui/hooks`. You also need `react`, `viem`, `wagmi`, and `@tanstack/react-query` configured in your app.
 
-You'll also need these peer dependencies if you don't already have them:
+## Usage
 
-```bash
-npm install react @types/react viem wagmi @tanstack/react-query
-```
-
-## Components
-
-### Address
-
-A React component for displaying Ethereum addresses with ENS support, avatars, and block explorer links.
-
-#### Props
-
-- `address?` - The Ethereum address to display (optional)
-- `disableAddressLink?` - Whether to disable the link to block explorer (optional)
-- `format?` - Display format for the address - "short" | "long" (optional)
-- `size` - Size of the component - "xs" | "sm" | "base" | "lg" | "xl" | "2xl" | "3xl" (required)
-- `onlyEnsOrAddress?` - Whether to show only ENS name or address without additional info (optional)
-- `chain?` - The blockchain chain to use for block explorer links and ENS resolution (optional, defaults to mainnet)
-
-#### Example
+Import the styles once in your root layout, then use any component:
 
 ```tsx
+import "@scaffold-ui/components/styles.css";
 import { Address } from "@scaffold-ui/components";
-import { optimism } from "viem/chains";
 
-function MyComponent() {
-  return (
-    <Address
-      address="0x1234567890123456789012345678901234567890"
-      size="base"
-      format="short"
-      disableAddressLink={false}
-      onlyEnsOrAddress={false}
-      chain={optimism} // Optional: specify chain for block explorer links
-    />
-  );
+export default function Profile() {
+  return <Address address="0xd8da6bf26964af9d7eed9e03e53415d37aa96045" />;
 }
 ```
 
-## Development
+See the [docs](https://ui.scaffoldeth.io/components) for the full component list, props, and examples.
 
-```bash
-# Install dependencies
-pnpm install
+## License
 
-# Build the package
-pnpm build
-
-# Watch for changes during development
-pnpm dev
-
-# Lint the code
-pnpm lint
-
-# Format the code
-pnpm format
-```
+MIT

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -2,6 +2,7 @@
   "name": "@scaffold-ui/components",
   "version": "0.1.10",
   "description": "React components for scaffold-ui",
+  "license": "MIT",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/debug-contracts/README.md
+++ b/packages/debug-contracts/README.md
@@ -1,46 +1,47 @@
 # @scaffold-ui/debug-contracts
 
-Debug contracts component.
+The Scaffold-ETH 2 contract debugger UI as a standalone React component. Drop it into any wagmi-based React app.
 
-## Installation
+**[Documentation](https://ui.scaffoldeth.io/debug-contracts)** · [Repo](https://github.com/scaffold-eth/scaffold-ui)
 
-**Note**: This package requires `@scaffold-ui/components` and `@scaffold-ui/hooks` as peer dependencies.
+## Install
 
 ```bash
-npm install @scaffold-ui/components @scaffold-ui/hooks @scaffold-ui/debug-contracts
+npm install @scaffold-ui/debug-contracts @scaffold-ui/components @scaffold-ui/hooks
 # or
-yarn add @scaffold-ui/components @scaffold-ui/hooks @scaffold-ui/debug-contracts
+yarn add @scaffold-ui/debug-contracts @scaffold-ui/components @scaffold-ui/hooks
 # or
-pnpm add @scaffold-ui/components @scaffold-ui/hooks @scaffold-ui/debug-contracts
+pnpm add @scaffold-ui/debug-contracts @scaffold-ui/components @scaffold-ui/hooks
 ```
 
-#### Props
-
-- `contracts` (required): An object containing deployed contracts organized by chain ID, where each contract includes address and ABI
-- `chainId` (required): The chain ID to use for debugging contracts (number)
-- `blockExplorerBaseUrl` (optional): Base URL of the block explorer. The component appends `/address/{addr}` per rendered address. Defaults to `/blockexplorer` for local chain (31337) and to the chain's configured explorer otherwise.
+`@scaffold-ui/debug-contracts` peer-depends on `@scaffold-ui/components` and `@scaffold-ui/hooks`.
 
 ## Usage
 
 ```tsx
-import { Contract } from "@scaffold-ui/debug-contracts";
 import "@scaffold-ui/debug-contracts/styles.css";
+import { Contract } from "@scaffold-ui/debug-contracts";
 import { sepolia } from "viem/chains";
 
-// Define your deployed contracts
-const deployedContracts = {
+const deployedContract = {
   address: "0xBf6D6faFE5B0C009E5447A27A94E093F490Dd0FC",
   abi: [
-    // ... your contract ABI
+    /* ... */
   ],
 } as const;
 
-function App() {
+export default function Debug() {
   return (
     <Contract
-      contracts={deployedContracts}
+      contracts={deployedContract}
       chainId={sepolia.id}
     />
   );
 }
 ```
+
+See the [docs](https://ui.scaffoldeth.io/debug-contracts/Contract) for all props.
+
+## License
+
+MIT

--- a/packages/debug-contracts/package.json
+++ b/packages/debug-contracts/package.json
@@ -2,6 +2,7 @@
   "name": "@scaffold-ui/debug-contracts",
   "version": "0.1.9",
   "description": "Debug contracts component for scaffold-ui",
+  "license": "MIT",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -1,69 +1,48 @@
 # @scaffold-ui/hooks
 
-A collection of React hooks for managing UI state.
+React hooks for building custom Ethereum UI — ENS resolution, balance fetching with USD conversion, address validation, ETH-amount input handling.
 
-## Installation
+**[Documentation](https://ui.scaffoldeth.io/hooks)** · [Repo](https://github.com/scaffold-eth/scaffold-ui)
+
+## Install
 
 ```bash
 npm install @scaffold-ui/hooks
 # or
 yarn add @scaffold-ui/hooks
+# or
+pnpm add @scaffold-ui/hooks
 ```
 
-## Hooks
+You also need `react`, `viem`, `wagmi`, and `@tanstack/react-query` configured in your app.
 
-### useAddress
-
-A hook for managing Ethereum addresses with ENS support.
+## Usage
 
 ```tsx
 import { useAddress } from "@scaffold-ui/hooks";
 import { useAccount } from "wagmi";
 
-function AddressInfo() {
+export function Profile() {
   const { address } = useAccount();
-
-  const {
-    checkSumAddress,
-    ens,
-    ensAvatar,
-    isEnsNameLoading,
-    blockExplorerAddressLink,
-    isValidAddress,
-    shortAddress,
-    blockieUrl,
-  } = useAddress({
-    address,
-    chain: mainnet, // Optional chain parameter
-  });
+  const { ens, ensAvatar, shortAddress, blockExplorerAddressLink } = useAddress({ address });
 
   return (
-    <div>
-      {isEnsNameLoading ? (
-        <div>Loading ENS name...</div>
-      ) : (
-        <div>
-          <img
-            src={ensAvatar ?? blockieUrl}
-            alt="Avatar"
-          />
-          <div>ENS Name: {ens ?? "No ENS name"}</div>
-          <div>Address: {checkSumAddress}</div>
-          <div>Short Address: {shortAddress}</div>
-          <a
-            href={blockExplorerAddressLink}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            View on Block Explorer
-          </a>
-          {isValidAddress && <div>✓ Valid Address</div>}
-        </div>
-      )}
-    </div>
+    <a
+      href={blockExplorerAddressLink}
+      target="_blank"
+      rel="noreferrer"
+    >
+      <img
+        src={ensAvatar ?? undefined}
+        alt=""
+      />
+      {ens ?? shortAddress}
+    </a>
   );
 }
 ```
+
+See the [docs](https://ui.scaffoldeth.io/hooks) for every hook and return value.
 
 ## License
 

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -2,6 +2,7 @@
   "name": "@scaffold-ui/hooks",
   "version": "0.1.8",
   "description": "React hooks for scaffold-ui",
+  "license": "MIT",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
## Summary

Closes #30. Pass over READMEs, contributing guide, and LICENCE.

- **Root README** — overview + packages table + quick start, no longer dev-instructions only. Not rendered on npm, so it's purpose-built for GitHub.
- **CONTRIBUTING.md** — new. Absorbs the local dev workflows (example app + Scaffold-ETH 2 setup) that used to live in the root README, plus changeset / lint / format / docs editing.
- **Package READMEs** — consistent shape across components / hooks / debug-contracts: tagline → install (npm + yarn + pnpm) → minimal example → link to the corresponding docs install page.
- **example/README.md** — replaced create-next-app boilerplate with a one-liner pointing at CONTRIBUTING.
- **Docs site** — new `/debug-contracts` installation page mirroring `/components` and `/hooks`, wired into the sidebar and the landing page.
- **LICENCE** — added at the root (MIT, matching scaffold-eth-2's `BuidlGuidl` attribution and `LICENCE` spelling). Added `"license": "MIT"` to all three published packages' `package.json` and a patch-bump changeset for it.

## Test plan

- [ ] `pnpm install` and `pnpm dev` still work (no behavioral changes, just metadata)
- [ ] Render the root README on GitHub — relative links resolve to packages, CONTRIBUTING, LICENCE
- [ ] Render package READMEs on npm preview — install snippets show npm/yarn/pnpm; doc links go to install pages
- [ ] `cd docs && pnpm dev` — `/debug-contracts` renders the new installation page; sidebar shows the new entry
- [ ] Confirm `BuidlGuidl` is the right copyright holder