### PR TITLE
Change input text size

### DIFF
--- a/.changeset/clear-mice-nail.md
+++ b/.changeset/clear-mice-nail.md
@@ -1,0 +1,5 @@
+---
+"@scaffold-ui/components": patch
+---
+
+change font-size of the inputs to text-base

--- a/example/app/components/UseAddressInputExample.tsx
+++ b/example/app/components/UseAddressInputExample.tsx
@@ -17,6 +17,7 @@ export const UseAddressInputExample = () => {
         "--color-sui-input-border": isDark ? "#4ade80" : "#22c55e",
         "--color-sui-input-background": isDark ? "#14532d" : "#dcfce7",
         "--color-sui-input-text": isDark ? "#dcfce7" : "#166534",
+        "--color-sui-accent": isDark ? "#dcfce7" : "#14532d",
       }) as CSSProperties,
     [isDark],
   );
@@ -27,6 +28,7 @@ export const UseAddressInputExample = () => {
         "--color-sui-input-border": isDark ? "#f87171" : "#ff6b6b",
         "--color-sui-input-background": isDark ? "#7f1d1d" : "#fff5f5",
         "--color-sui-input-text": isDark ? "#fecaca" : "#d63031",
+        "--color-sui-accent": isDark ? "#fecaca" : "#7f1d1d",
       }) as CSSProperties,
     [isDark],
   );

--- a/packages/components/src/Input/BaseInput.tsx
+++ b/packages/components/src/Input/BaseInput.tsx
@@ -90,7 +90,7 @@ export const BaseInput = <T extends { toString: () => string } | undefined = str
     >
       {prefix}
       <input
-        className={`w-full h-[2.2rem] min-h-[2.2rem] px-4 border-0 bg-transparent font-medium placeholder:text-sui-accent/70 focus:text-sui-input-text text-sui-input-text disabled:text-sui-base-content/40 text-sm focus:outline-none focus:ring-0 ${
+        className={`w-full h-[2.2rem] min-h-[2.2rem] px-4 border-0 bg-transparent font-medium placeholder:text-sui-accent/70 focus:text-sui-input-text text-sui-input-text disabled:text-sui-base-content/40 text-base focus:outline-none focus:ring-0 ${
           disabled ? "cursor-not-allowed" : ""
         }`}
         placeholder={placeholder}


### PR DESCRIPTION
Makes the font size of the inputs `text-base` to fix #79. Ens text size is already base. Font size is looking good in the input of the same height as before, so I think it won't break anything.

See #79 and #95 for details

Also updated `AddressInput` example colors

Before:
<img width="677" height="427" alt="Screenshot 2026-05-18 at 18 25 15" src="https://github.com/user-attachments/assets/c1436054-6a86-468c-9dbf-b8e88724c727" />

After:
<img width="677" height="428" alt="Screenshot 2026-05-18 at 18 24 54" src="https://github.com/user-attachments/assets/dfa79833-7dbc-4bd5-9108-90a9002663d2" />

Fixes #79

